### PR TITLE
mapfixes

### DIFF
--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -27,7 +27,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/loading_bay)
 "ai" = (
-/turf/simulated/floor,
+/turf/simulated/floor/airless,
 /area/space)
 "aj" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -116,7 +116,7 @@
 /area/ship/scrap/enclave)
 "ar" = (
 /obj/structure/lattice,
-/turf/simulated/floor,
+/turf/simulated/floor/airless,
 /area/space)
 "as" = (
 /obj/structure/lattice,
@@ -822,6 +822,7 @@
 	has_handle = "#800000";
 	name = "shank"
 	},
+/obj/item/synthesized_instrument/synthesizer,
 /turf/simulated/floor,
 /area/ship/scrap/fore_port_underside_maint)
 "bE" = (
@@ -1355,15 +1356,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/scrap/enclave)
-"ki" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "trash_sort"
-	},
-/obj/random/trash,
-/obj/random/single/textbook,
-/turf/simulated/floor,
-/area/ship/scrap/loading_bay)
 "kO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1434,7 +1426,7 @@
 	pixel_x = 9;
 	pixel_y = 7
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/airless,
 /area/space)
 "oO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1516,6 +1508,15 @@
 /obj/structure/bed/chair/padded/beige,
 /turf/simulated/floor/carpet/red,
 /area/ship/scrap/enclave)
+"rW" = (
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 0;
+	pixel_y = -10;
+	pixel_z = 32;
+	master_tag = "lower_cargo"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "rZ" = (
 /obj/item/chems/food/snacks/fish/mollusc,
 /obj/item/mollusc,
@@ -1767,7 +1768,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/airless,
 /area/space)
 "FT" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1841,7 +1842,7 @@
 	icon_state = "outlet";
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/airless,
 /area/space)
 "IG" = (
 /obj/structure/bed/chair/comfy/green{
@@ -2032,6 +2033,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/loading_bay)
+"Sz" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "trash_sort"
+	},
+/obj/random/trash,
+/obj/random/single/textbook,
+/turf/simulated/floor,
+/area/ship/scrap/loading_bay)
 "SC" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2086,15 +2096,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/loading_bay)
-"WC" = (
-/obj/machinery/access_button/airlock_exterior{
-	pixel_x = 0;
-	pixel_y = -10;
-	pixel_z = 32;
-	master_tag = "lower_cargo"
-	},
-/turf/simulated/floor,
-/area/space)
 "Xo" = (
 /obj/structure/hygiene/drain,
 /turf/simulated/floor,
@@ -5294,7 +5295,7 @@ aw
 aB
 aJ
 qK
-WC
+rW
 aa
 aa
 aa
@@ -5688,7 +5689,7 @@ SC
 aU
 yO
 iD
-ki
+Sz
 yO
 tD
 yO

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -810,6 +810,9 @@
 	dir = 8
 	},
 /obj/item/storage/firstaid/regular,
+/obj/structure/sign/warning/fall{
+	pixel_w = -31
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/cargo/lower)
 "bU" = (
@@ -2405,6 +2408,12 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/cargo/lower)
+"iR" = (
+/obj/item/mollusc/barnacle{
+	pixel_z = 19
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "iW" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -2886,6 +2895,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/scrap/cargo/lower)
+"AH" = (
+/obj/item/mollusc/barnacle{
+	pixel_w = 17
+	},
+/turf/space,
+/area/space)
 "Bb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3230,6 +3245,10 @@
 "Qb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
+/obj/structure/sign/warning/fall{
+	pixel_y = 0;
+	pixel_w = 32
+	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
 "Qc" = (
@@ -3242,6 +3261,12 @@
 /mob/living/simple_animal/cat/fluff/ran,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/science/fabricaton)
+"Qu" = (
+/obj/item/mollusc/barnacle{
+	pixel_z = 19
+	},
+/turf/space,
+/area/space)
 "Rb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5721,7 +5746,7 @@ aa
 aa
 aa
 aa
-aa
+AH
 aa
 aa
 aa
@@ -5813,7 +5838,7 @@ tf
 aa
 aa
 aa
-aa
+AH
 aa
 aa
 XF
@@ -7277,7 +7302,7 @@ aa
 aa
 aa
 aa
-Ei
+iR
 ap
 az
 qb
@@ -7294,7 +7319,7 @@ Nb
 dz
 Sb
 DX
-aa
+Qu
 er
 eH
 er

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -168,12 +168,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/ship/scrap/command/captain)
 "ba" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
-	pixel_y = -32
-	},
 /obj/machinery/computer/modular/preset/cardslot/command{
 	icon_state = "computer";
 	dir = 4
@@ -1732,12 +1726,11 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/sign/redcross{
+	pixel_w = 32
+	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/crew/hallway/starboard)
-"eJ" = (
-/obj/structure/sign/redcross,
-/turf/simulated/wall,
-/area/ship/scrap/crew/medbay)
 "eL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 2;
@@ -1749,6 +1742,9 @@
 /obj/machinery/bodyscanner{
 	icon_state = "body_scanner_0";
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
@@ -2051,7 +2047,6 @@
 /obj/structure/table/standard,
 /obj/item/glass_extra/straw,
 /obj/item/toy/therapy_blue,
-/obj/item/chems/spray/cleaner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/defibrillator/compact/loaded,
 /obj/item/modular_computer/telescreen/preset/medical{
@@ -2420,7 +2415,7 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "ge" = (
 /obj/machinery/light_switch{
@@ -2438,7 +2433,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "gg" = (
 /obj/effect/paint/brown,
@@ -2609,13 +2604,13 @@
 	icon_state = "alarm0";
 	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "gw" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/skele_stand{
 	anchored = 0;
-	name = "Spookers"
+	name = "Grand Archivist Spookers"
 	},
 /obj/structure/cable{
 	icon_state = "2-9"
@@ -2625,14 +2620,14 @@
 	level = 2
 	},
 /obj/item/synthesized_instrument/trumpet,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "gx" = (
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "gy" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -2698,7 +2693,7 @@
 /area/ship/scrap/cargo)
 "gI" = (
 /obj/random/maintenance,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "gL" = (
 /obj/structure/disposalpipe/segment,
@@ -5120,7 +5115,8 @@
 /turf/simulated/floor/plating,
 /area/ship/scrap/command/bridge)
 "rR" = (
-/turf/simulated/floor/plating,
+/obj/item/flashlight,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "sb" = (
 /obj/effect/floor_decal/corner/blue{
@@ -5354,8 +5350,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/item/clothing/head/powdered_wig,
-/obj/item/clothing/suit/judgerobe,
+/obj/item/taperoll/bureaucracy,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "vS" = (
@@ -5480,6 +5475,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/engine/aft)
+"xx" = (
+/obj/item/mollusc/barnacle{
+	pixel_w = 17
+	},
+/turf/space,
+/area/space)
 "xL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -5799,7 +5800,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/icecream_vat,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "Dq" = (
 /obj/effect/paint/brown,
@@ -6529,8 +6530,12 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/item/flashlight,
-/turf/simulated/floor/plating,
+/obj/structure/bookcase,
+/obj/item/book/skill,
+/obj/item/book/skill,
+/obj/item/book/skill,
+/obj/item/book/skill,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "NN" = (
 /obj/machinery/requests_console{
@@ -6569,7 +6574,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "Og" = (
 /obj/machinery/power/apc{
@@ -6698,6 +6703,9 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
+/obj/item/mollusc/barnacle{
+	pixel_w = 17
+	},
 /turf/simulated/floor/airless,
 /area/ship/scrap/command/captain)
 "Qb" = (
@@ -6787,7 +6795,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/yew,
 /area/ship/scrap/unused)
 "Rv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6805,6 +6813,12 @@
 /obj/structure/handrai,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/saloon)
+"RT" = (
+/obj/item/mollusc/barnacle{
+	pixel_w = -15
+	},
+/turf/space,
+/area/space)
 "RW" = (
 /obj/machinery/atmospherics/unary/engine{
 	icon_state = "nozzle";
@@ -6942,6 +6956,9 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/toilets)
+"UI" = (
+/turf/simulated/floor/wood/yew,
+/area/ship/scrap/unused)
 "UP" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "scram"
@@ -9117,7 +9134,7 @@ aa
 aa
 aa
 aa
-aa
+xx
 aa
 aa
 aa
@@ -9604,7 +9621,7 @@ aa
 aa
 Lx
 aa
-aa
+xx
 aa
 Lx
 cy
@@ -9916,7 +9933,7 @@ aa
 aa
 aa
 aa
-aa
+xx
 aa
 aa
 nZ
@@ -10919,7 +10936,7 @@ dG
 de
 ee
 ee
-eJ
+ee
 fb
 ee
 ee
@@ -11172,7 +11189,7 @@ Im
 ee
 NI
 rR
-rR
+UI
 gQ
 sS
 sS
@@ -11905,7 +11922,7 @@ aa
 aa
 aa
 aa
-aa
+RT
 aa
 aa
 aa

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -284,6 +284,14 @@
 /obj/machinery/ntnet_relay,
 /turf/simulated/floor/bluegrid,
 /area/ship/scrap/comms)
+"dN" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood/bamboo,
+/area/space)
+"dX" = (
+/obj/structure/table/woodentable_reinforced,
+/turf/simulated/floor/wood/bamboo,
+/area/space)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -346,6 +354,17 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/open,
 /area/ship/scrap/maintenance/solars)
+"iq" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "iz" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
@@ -489,6 +508,12 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ship/scrap/bridge_unused)
+"pv" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 0
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "pC" = (
 /obj/item/wrench,
 /obj/structure/handrai{
@@ -498,6 +523,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"qh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch/autoname/command,
+/turf/simulated/floor/plating,
+/area/ship/scrap/command/bridge_upper)
 "qw" = (
 /obj/machinery/light_switch{
 	pixel_z = 0;
@@ -537,6 +567,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"sI" = (
+/obj/machinery/door/airlock/hatch/autoname/command,
+/turf/simulated/floor/tiled/monotile,
+/area/space)
 "sX" = (
 /obj/machinery/door/window/westleft,
 /obj/structure/cable{
@@ -576,6 +610,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/bridge_unused)
+"uX" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/wood/bamboo,
+/area/space)
 "vi" = (
 /obj/structure/handrai{
 	tag = "icon-handrail (WEST)";
@@ -586,6 +624,9 @@
 /area/space)
 "vC" = (
 /obj/machinery/door/firedoor,
+/obj/structure/sign/warning/fall{
+	pixel_w = 32
+	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
 "wc" = (
@@ -715,6 +756,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"AM" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -14
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "BD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -722,6 +769,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"CB" = (
+/turf/simulated/floor/tiled/monotile,
+/area/space)
 "Db" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -859,6 +909,9 @@
 /obj/machinery/message_server,
 /turf/simulated/floor/bluegrid,
 /area/ship/scrap/comms)
+"JD" = (
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "Ko" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -911,6 +964,10 @@
 /obj/machinery/light/small{
 	icon_state = "bulb_map";
 	dir = 8
+	},
+/obj/structure/sign/warning/fall{
+	pixel_z = 0;
+	pixel_w = -32
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
@@ -1065,6 +1122,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/command/bridge_upper)
+"SF" = (
+/turf/space,
+/turf/simulated/open,
+/area/space)
 "SO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1097,6 +1158,9 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"Tu" = (
+/turf/simulated/floor/wood/bamboo,
+/area/space)
 "Tx" = (
 /obj/machinery/r_n_d/server/core,
 /turf/simulated/floor/bluegrid,
@@ -1107,6 +1171,12 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless,
+/area/space)
+"Uv" = (
+/obj/item/mollusc/barnacle{
+	pixel_w = 16
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/space)
 "Ux" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -1152,6 +1222,12 @@
 "Xb" = (
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/command/bridge_upper)
+"Xp" = (
+/obj/item/mollusc/barnacle{
+	pixel_w = -17
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "Xu" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1205,6 +1281,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/scrap/command/bridge_upper)
+"YG" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/space,
+/area/space)
 "Zx" = (
 /obj/structure/handrai{
 	tag = "icon-handrail (EAST)";
@@ -3201,8 +3281,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+SF
+SF
 ax
 ax
 ax
@@ -3282,8 +3362,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+SF
+SF
 ax
 ax
 ax
@@ -3364,7 +3444,7 @@ aa
 aa
 aa
 aa
-aa
+SF
 ax
 ax
 ax
@@ -3934,7 +4014,7 @@ aa
 aa
 ax
 ax
-ax
+AM
 ax
 ax
 ax
@@ -4105,7 +4185,7 @@ KG
 ax
 ax
 ax
-ax
+Uv
 vi
 aV
 au
@@ -4206,7 +4286,7 @@ ax
 ax
 ax
 ax
-ax
+pv
 ax
 ax
 ax
@@ -4259,10 +4339,10 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
+JD
+JD
+YG
+JD
 ax
 Tt
 ax
@@ -4341,10 +4421,10 @@ ax
 aa
 aa
 aa
-ax
-ax
-ax
-ax
+JD
+Tu
+Tu
+uX
 ax
 Yq
 aV
@@ -4419,14 +4499,14 @@ RZ
 HN
 bE
 SQ
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+iq
+iq
+iq
+iq
+JD
+dX
+dX
+uX
 ax
 Tt
 Rk
@@ -4500,15 +4580,15 @@ YA
 rl
 fi
 PZ
-SQ
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+qh
+CB
+CB
+CB
+sI
+Tu
+Tu
+Tu
+uX
 ax
 Xu
 yt
@@ -4583,14 +4663,14 @@ wc
 nZ
 ZT
 SQ
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+iq
+iq
+iq
+iq
+JD
+Tu
+Tu
+uX
 ax
 Yq
 aV
@@ -4669,15 +4749,15 @@ ax
 aa
 aa
 aa
-ax
-ax
-ax
-ax
+JD
+dN
+Tu
+uX
 ax
 br
 ax
 ax
-ax
+Xp
 aV
 aV
 xe
@@ -4691,7 +4771,7 @@ ax
 ax
 ax
 ax
-ax
+Xp
 ax
 ax
 ax
@@ -4751,10 +4831,10 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
+JD
+JD
+YG
+JD
 ax
 wf
 ax
@@ -5269,7 +5349,7 @@ ax
 ax
 ax
 ax
-ax
+pv
 ax
 aa
 aa
@@ -5577,8 +5657,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+SF
+SF
 ax
 ax
 ax
@@ -5660,7 +5740,7 @@ aa
 aa
 aa
 aa
-aa
+SF
 ax
 ax
 ax
@@ -5742,8 +5822,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+SF
+SF
 ax
 ax
 ax


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->
-Removed space cleaner from medbay.  Doctors, rush your asses down to laundry if you’ve got a nasty mess to contend with.
-Removed extra air alarm in first mate’s office
-Red tape added to captain’s closet.
-Fall warnings added to various floors
-Medbay sign made visible once more
-Added… uh, open space.  In space. In very limited conditions where rocks lay underneath said space
-Enclave plating made airless – not genocide to my relief
-Added lotsa barnacles
-Liberararbrery added – skill books strewn about by frustrated library ying that, due to severe, untreated brain damage, wasn’t even smart enough to operate a bookshelf.  

