### PR TITLE
Baxxid culture/language

### DIFF
--- a/code/modules/scavstation_shared_content/_scavs.dme
+++ b/code/modules/scavstation_shared_content/_scavs.dme
@@ -11,9 +11,21 @@
 #include "items/suit_cycler.dm"
 #include "items/turfs.dm"
 #include "map/culture.dm"
+#include "map/culturebaxxid.dm"
+#include "map/languagebaxxid.dm"
 #include "map/overrides.dm"
 #include "lobby/music.dm"
 #include "species/baxxid.dm"
 #include "species/yinglet.dm"
 #include "species/yinglet_organs.dm"
 #include "species/yinglet_accessories.dm"
+
+// BEGIN_INTERNALS
+// END_INTERNALS
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+// BEGIN_INCLUDE
+// END_INCLUDE

--- a/code/modules/scavstation_shared_content/_scavs.dme
+++ b/code/modules/scavstation_shared_content/_scavs.dme
@@ -19,13 +19,3 @@
 #include "species/yinglet.dm"
 #include "species/yinglet_organs.dm"
 #include "species/yinglet_accessories.dm"
-
-// BEGIN_INTERNALS
-// END_INTERNALS
-// BEGIN_FILE_DIR
-#define FILE_DIR .
-// END_FILE_DIR
-// BEGIN_PREFERENCES
-// END_PREFERENCES
-// BEGIN_INCLUDE
-// END_INCLUDE

--- a/code/modules/scavstation_shared_content/map/culturebaxxid.dm
+++ b/code/modules/scavstation_shared_content/map/culturebaxxid.dm
@@ -1,0 +1,72 @@
+/decl/cultural_info/faction/baxxid
+	name = FACTION_BAXXID
+	description = "For myriad reasons, your people abandoned your homeworld for the stars, becoming nomads. \
+	After some initial tensions with humankind, the Baxxid have become embedded in Human society, \
+	carving a niche for themselves as accountants, researchers, and receptionists."
+	subversive_potential = 25
+	//make cooler and less crappy by at least fifteen ounces
+
+/decl/cultural_info/culture/baxxid
+	name = CULTURE_BAXXID
+	description = "You represent one of the many Baxxid clans in society."
+	secondary_langs = list(
+		LANGUAGE_HUMAN,
+		LANGUAGE_SIGN,
+		LANGUAGE_BAXXID
+	)
+
+	//ditto
+	var/list/middle_syllables = list(
+		"z",
+		"e",
+		"s",
+		"r",
+		"t",
+		"tt",
+		"rk",
+		"a",
+		"kk",
+		"z",
+	)
+	var/list/end_syllables = list(
+		"na",
+		"kka",
+		"kki",
+		"kkit",
+		"let",
+		"ria",
+		"pin",
+		"ppie",
+		"bzig",
+		"jack",
+		"s",
+		"ck",
+		"ss",
+		"lly",
+		"k",
+		"t"
+	)
+	//fix for Baxxid naming conventions (ffBnc)
+
+/decl/cultural_info/culture/baxxid/get_random_name(var/gender)
+	// First syllable; ffBnc
+	. = pick(GLOB.alphabet_no_vowels)
+	if(. == "h")
+		if(prob(50))
+			. = "[pick("c", "s")][.]"
+	else if(prob(5))
+		. += "r"
+	. += pick(GLOB.vowels)
+
+	//Main body of name; ffBnc
+	var/hyphenated = prob(10)
+	var/syllables = hyphenated ? rand(1,2) : rand(1,3)
+	for(var/i = 1 to syllables-1)
+		. = "[.][pick(middle_syllables)][pick(GLOB.vowels)]"
+
+	// Terminate and format; ffBnc
+	. += pick(end_syllables)
+	. = capitalize(lowertext(.))
+	if(hyphenated)
+		. = "[.]-[.]"
+

--- a/code/modules/scavstation_shared_content/map/languagebaxxid.dm
+++ b/code/modules/scavstation_shared_content/map/languagebaxxid.dm
@@ -4,7 +4,7 @@
 	speech_verb = "rumbles"
 	whisper_verb = "hisses"
 	colour = ""
-	key = "b"
+	key = "x"
 	flags = WHITELISTED
 	shorthand = "BX"
 	partial_understanding = list()

--- a/code/modules/scavstation_shared_content/map/languagebaxxid.dm
+++ b/code/modules/scavstation_shared_content/map/languagebaxxid.dm
@@ -1,0 +1,18 @@
+/datum/language/baxxid
+	name = LANGUAGE_BAXXID
+	desc = "The language spoken by the Baxxid."
+	speech_verb = "rumbles"
+	whisper_verb = "hisses"
+	colour = ""
+	key = "b"
+	flags = WHITELISTED
+	shorthand = "BX"
+	partial_understanding = list()
+	syllables = list(
+		"sh", "sshh", "ssshhh", "hs", "hhss", "hhhsss", "hr", "hhr", "hhhr", "rn", "rrnn", "rrrnn", "ng", "nng", "rs",
+		"rrss", "rrrsss", "sr", "ssrr", "sssrrr", "ng", "nng", "r", "rr", "rrr", "s", "ss", "sss", "h", "hh", "hhh",
+		"kh", "kkhh", "kkhhh", "hk", "hhkk", "hhhkk", "kr", "kkrr", "kkrrr", "rk", "rrkk", "rrrkk", "e", "i", "rh", "rrhh",
+		"rrrhhh", "nr", "nnrr", "nnrrr", "x", "xx", "xh", "xxhh", "xxhhh", "hx", "hhxx", "hhhxx", "rx", "rrxx", "rrrxx",
+		"kx", "kkxx", "xk", "xxkk", "sx", "ssxx", "sssxx", "xs", "xxss", "xxsss", "nx", "nnxx", "xn", "xxnn", "ch",
+		"t", "z", "zz", "zzz"
+	)

--- a/code/modules/scavstation_shared_content/species/baxxid.dm
+++ b/code/modules/scavstation_shared_content/species/baxxid.dm
@@ -46,6 +46,8 @@
 		if(first_char != lowertext(first_char))
 			hnnn = uppertext(capitalize(hnnn))
 		. = "[hnnn][uppertext(.)]"
+	if(autohiss_exempt && (lang.name in autohiss_exempt))
+		return message
 
 /obj/item/organ/internal/eyes/baxxid
 	eye_icon = 'code/modules/scavstation_shared_content/icons/species/baxxid/eyes.dmi'

--- a/code/modules/scavstation_shared_content/species/baxxid.dm
+++ b/code/modules/scavstation_shared_content/species/baxxid.dm
@@ -35,8 +35,9 @@
 		TAG_RELIGION =  list(RELIGION_OTHER, RELIGION_ATHEISM, RELIGION_AGNOSTICISM)
 	)
 
-/datum/language/baxxid
 /datum/species/baxxid/handle_autohiss(message, datum/language/lang, mode)
+	if(autohiss_exempt && (lang.name in autohiss_exempt))
+		return message
 	. = message
 	if(!istype(lang, /datum/language/baxxid))
 		var/hnnn = "H"
@@ -46,8 +47,7 @@
 		if(first_char != lowertext(first_char))
 			hnnn = uppertext(capitalize(hnnn))
 		. = "[hnnn][uppertext(.)]"
-	if(autohiss_exempt && (lang.name in autohiss_exempt))
-		return message
+
 
 /obj/item/organ/internal/eyes/baxxid
 	eye_icon = 'code/modules/scavstation_shared_content/icons/species/baxxid/eyes.dmi'

--- a/code/modules/scavstation_shared_content/species/baxxid.dm
+++ b/code/modules/scavstation_shared_content/species/baxxid.dm
@@ -28,6 +28,13 @@
 		BP_EYES =     /obj/item/organ/internal/eyes/baxxid
 		)
 
+	available_cultural_info = list(
+		TAG_CULTURE =   list(CULTURE_BAXXID, CULTURE_OTHER),
+		TAG_HOMEWORLD = list(HOME_SYSTEM_STATELESS),
+		TAG_FACTION =   list(FACTION_BAXXID, FACTION_OTHER),
+		TAG_RELIGION =  list(RELIGION_OTHER, RELIGION_ATHEISM, RELIGION_AGNOSTICISM)
+	)
+
 /datum/language/baxxid
 /datum/species/baxxid/handle_autohiss(message, datum/language/lang, mode)
 	. = message
@@ -80,3 +87,4 @@
 	eye_attack_text = "an enormous forelimb"
 	eye_attack_text_victim = "an enormous forelimb"
 	attack_name = "forelimb stab"
+

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -9,7 +9,7 @@
 	#define CULTURE_SCAV_TRIBE       "Tribal Yinglet"
 	#define FACTION_SCAV             "Scav"
 	#define LANGUAGE_BAXXID          "Baxxid"
-	#define CULTURE_BAXXID           "Baxxid"
+	#define CULTURE_BAXXID           "Baxxid Clans"
 	#define FACTION_BAXXID           "Baxxid Nomad"
 
 	#include "../../code/modules/scavstation_shared_content/_scavs.dme"

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -10,7 +10,7 @@
 	#define FACTION_SCAV             "Scav"
 	#define LANGUAGE_BAXXID          "Baxxid"
 	#define CULTURE_BAXXID           "Baxxid"
-	#define FACTION_BAXXID           "Baxxid Clansmember"
+	#define FACTION_BAXXID           "Baxxid Nomad"
 
 	#include "../../code/modules/scavstation_shared_content/_scavs.dme"
 	#include "tradeship_antagonists.dm"

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -8,6 +8,9 @@
 	#define CULTURE_SCAV_ENCLAVE     "Enclave Yinglet"
 	#define CULTURE_SCAV_TRIBE       "Tribal Yinglet"
 	#define FACTION_SCAV             "Scav"
+	#define LANGUAGE_BAXXID          "Baxxid"
+	#define CULTURE_BAXXID           "Baxxid"
+	#define FACTION_BAXXID           "Baxxid Clansmember"
 
 	#include "../../code/modules/scavstation_shared_content/_scavs.dme"
 	#include "tradeship_antagonists.dm"


### PR DESCRIPTION
Summary:
- Added Baxxid language, culture/faction.
- Edited files necessary to implement.

Commit log:
Feb. 28, 2020
- Changed language keybind from "b" to "x" in languagebaxxid.dm (line 7)
- Removed autogenerated content in _scavs.dme (line 23 to end of file)
- Removed "/datum/language/baxxid" from baxxid.dm (line 37)
- Moved autohiss in baxxid.dm (lines 39 & 40)
- Changed definition of CULTURE_BAXXID from "Baxxid" to "Baxxid Clans" in tradeship.dm (line 12)

Feb. 27, 2020
- Created culturebaxxid.dm (Baxxid culture & faction)
- Created languagebaxxid.dm (Baxxid language)
- Added Baxxid culture & faction to baxxid.dm (lines 31 thru 37)
- Added autohiss exemption to baxxid.dm (lines 49 thru 50)
- Added filepaths to _scavs.dme (lines 14 thru 15)
- Added definitions to tradeship.dm (lines 11 thru 13)

Additional notes/related suggestions:
- Probably necessary to cull Baxxid language list later; depends on how it appears to non-speakers.
- Need to change Baxxid random name generation to differentiate it from Yinglet name generation; ideas for name-sounds and assistance changing this are greatly appreciated.
- Might want to toy with Baxxid culture and faction descriptions.
- Baxxid language proficiency or skillbook for other races?
- Any way to change how stuttering works in different languages? (_not_ remove it)


