### PR TITLE
Tradeship map: More newscasters and misc

### DIFF
--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -6,6 +6,11 @@
 /obj/machinery/door/unpowered/simple/wood{
 	name = "matriarch's quarters"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/enclave)
 "ae" = (
@@ -98,20 +103,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/enclave)
 "ar" = (
@@ -817,12 +821,12 @@
 /obj/item/clothing/under/yinglet,
 /obj/item/clothing/head/yinglet/scout,
 /obj/item/clothing/under/yinglet/scout,
-/obj/item/material/twohanded/spear,
 /obj/item/material/shard{
 	has_handle = "#800000";
 	name = "shank"
 	},
 /obj/item/synthesized_instrument/synthesizer,
+/obj/item/material/twohanded/spear/javelin,
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
 "bE" = (
@@ -1233,6 +1237,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/bamboo,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/enclave)
 "en" = (
@@ -1305,6 +1315,11 @@
 "hf" = (
 /obj/structure/lattice,
 /obj/machinery/light/small,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/enclave)
 "hg" = (
@@ -1333,6 +1348,7 @@
 /area/ship/trade/loading_bay)
 "iD" = (
 /obj/structure/closet/crate,
+/obj/item/clothing/suit/rubber,
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
 "iH" = (
@@ -1353,6 +1369,11 @@
 "iY" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/enclave)
@@ -1585,6 +1606,9 @@
 /obj/item/material/shard{
 	has_handle = "#800000";
 	name = "shank"
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
 /turf/simulated/floor,
 /area/ship/trade/fore_port_underside_maint)
@@ -1838,6 +1862,15 @@
 "IG" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/trade/enclave)

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -781,6 +781,9 @@
 /obj/random/clothing,
 /obj/random/clothing,
 /obj/random/clothing,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/lino,
 /area/ship/trade/crew/dorms1)
 "bS" = (
@@ -1183,6 +1186,9 @@
 /obj/item/storage/backpack/clown,
 /obj/item/bikehorn,
 /obj/item/storage/fancy/crayons,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/lino,
 /area/ship/trade/crew/dorms2)
 "cO" = (
@@ -1582,6 +1588,9 @@
 /area/ship/trade/drunk_tank)
 "dO" = (
 /obj/machinery/botany/editor,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science)
 "dP" = (
@@ -1806,6 +1815,12 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/structure/closet/secure_closet{
+	name = "secure engineering voidsuit locker";
+	req_access = list("ACCESS_CHIEF_ENGINEER")
+	},
+/obj/item/clothing/head/helmet/space/void/engineering/salvage,
+/obj/item/clothing/suit/space/void/engineering/salvage,
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/storage)
 "eo" = (
@@ -2215,7 +2230,6 @@
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/storage)
 "eZ" = (
-/obj/machinery/vending/engineering,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -2225,6 +2239,10 @@
 	dir = 4;
 	name = "Engineering Supply Storage APC";
 	pixel_w = 1
+	},
+/obj/machinery/vending/engineering{
+	icon_state = "engi";
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/storage)
@@ -2780,6 +2798,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/robotics_fabricator,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "vw" = (
@@ -2915,6 +2936,10 @@
 /obj/item/bedsheet/mime,
 /obj/machinery/light_switch{
 	pixel_y = -24
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/drunk_tank)

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -172,6 +172,9 @@
 	icon_state = "computer";
 	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/carpet,
 /area/ship/trade/command/fmate)
 "bb" = (
@@ -2115,6 +2118,9 @@
 /obj/item/chems/ivbag/blood/BPlus,
 /obj/item/chems/ivbag/blood/OMinus,
 /obj/item/chems/ivbag/blood/OPlus,
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "fw" = (
@@ -2693,6 +2699,9 @@
 /area/ship/trade/cargo)
 "gI" = (
 /obj/random/maintenance,
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
 "gL" = (
@@ -3707,6 +3716,9 @@
 	dir = 1;
 	icon_state = "computer";
 	initial_id_tag = "main_drive"
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
@@ -5749,6 +5761,9 @@
 /obj/random_multi/single_item/captains_spare_id,
 /obj/item/documents/tradehouse/account,
 /obj/item/documents/tradehouse/personnel,
+/obj/machinery/newscaster{
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "CD" = (
@@ -6234,6 +6249,9 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "Jr" = (
@@ -6539,11 +6557,7 @@
 	icon_state = "intact";
 	dir = 4
 	},
-/obj/structure/bookcase,
-/obj/item/book/skill,
-/obj/item/book/skill,
-/obj/item/book/skill,
-/obj/item/book/skill,
+/obj/structure/bookcase/skill_books/random,
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
 "NN" = (
@@ -6651,6 +6665,9 @@
 	name = "Solid Argument"
 	},
 /obj/structure/displaycase,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "Pc" = (
@@ -6849,6 +6866,9 @@
 /obj/machinery/light{
 	icon_state = "bulb1";
 	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/ship/trade/garden)


### PR DESCRIPTION
* Added newscasters to various rooms on the ship
* Replaced spear on enclave deck with javelin
* Increased amount of skill books that spawn in compartment 2-B
* Added salvage voidsuit to engineering storage

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->