### PR TITLE
Fixes #456 and small tradeship map changes

### DIFF
--- a/maps/tradeship/outfits/command.dm
+++ b/maps/tradeship/outfits/command.dm
@@ -4,7 +4,7 @@
 	shoes = /obj/item/clothing/shoes/black
 	pda_type = /obj/item/modular_computer/pda/captain
 	r_pocket = /obj/item/radio
-	id_type = /obj/item/card/id/gold
+	id_type = /obj/item/card/id/gold/tradeship_captain
 	suit = /obj/item/clothing/suit/storage/toggle/redcoat/officer
 
 /decl/hierarchy/outfit/job/tradeship/captain/post_equip(var/mob/living/carbon/human/H)
@@ -25,5 +25,12 @@
 	pda_type = /obj/item/modular_computer/pda/cargo
 	l_hand = /obj/item/material/clipboard
 	suit = /obj/item/clothing/suit/storage/toggle/redcoat/officiated
-	id_type = /obj/item/card/id/silver
+	id_type = /obj/item/card/id/silver/tradeship_first_mate
 	pda_type = /obj/item/modular_computer/pda/heads/hop
+
+//id cards
+/obj/item/card/id/gold/tradeship_captain
+	job_access_type = /datum/job/tradeship_captain
+
+/obj/item/card/id/silver/tradeship_first_mate
+	job_access_type = /datum/job/tradeship_first_mate

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -1082,6 +1082,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
+"cz" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
+/area/space)
 "cC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -1865,16 +1869,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/trade/maintenance/eva)
-"es" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/tool{
-	icon_state = "tool";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/trade/maintenance/techstorage)
 "et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -2416,12 +2410,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
 /area/ship/trade/cargo/lower)
-"jw" = (
-/obj/machinery/network/relay{
-	initial_network_id = "bearnet"
-	},
-/turf/simulated/floor/tiled,
-/area/ship/bearcat/broken1)
 "jD" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2561,6 +2549,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/ship/trade/science)
+"nz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/tool{
+	icon_state = "tool";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/trade/maintenance/techstorage)
 "ob" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -3157,6 +3155,10 @@
 /obj/machinery/mining/drill,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
+"Jv" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/space)
 "JM" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -3434,6 +3436,12 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/trade/maintenance/robot)
+"Wm" = (
+/obj/machinery/network/relay{
+	initial_network_id = "scavnet"
+	},
+/turf/simulated/floor/bluegrid,
+/area/ship/trade/maintenance/techstorage)
 "WT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5875,9 +5883,9 @@ cZ
 WZ
 iW
 WZ
-aa
-aa
 XF
+Jv
+Jv
 aa
 aa
 aa
@@ -5957,10 +5965,10 @@ NL
 ob
 jH
 WZ
-XF
-rv
-rv
-aa
+cz
+se
+se
+Jv
 aa
 aa
 aa
@@ -6039,10 +6047,10 @@ fL
 fL
 fL
 WZ
+Xb
+nz
+eJ
 se
-se
-se
-rv
 aa
 aa
 aa
@@ -6121,10 +6129,10 @@ dq
 dD
 Tb
 cS
-Xb
-es
-eJ
-se
+Yb
+et
+eK
+ef
 rv
 aa
 aa
@@ -6203,9 +6211,9 @@ dr
 dE
 dO
 cS
-Yb
-et
-eK
+rb
+eu
+eL
 ef
 rv
 fX
@@ -6285,9 +6293,9 @@ Ob
 cS
 nn
 cS
-rb
+Wm
 eu
-eL
+pn
 ef
 rv
 aa
@@ -6369,7 +6377,7 @@ dP
 tE
 uj
 ec
-pn
+tb
 ef
 se
 rv
@@ -6451,7 +6459,7 @@ Ub
 dZ
 Zb
 ew
-tb
+eN
 eV
 ef
 rv

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -6537,6 +6537,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/network/relay{
+	initial_network_id = "scavnet"
+	},
 /turf/simulated/floor/wood/yew,
 /area/ship/trade/unused)
 "Og" = (
@@ -6919,8 +6922,8 @@
 /turf/simulated/wall,
 /area/ship/trade/crew/toilets)
 "Uo" = (
-/obj/machinery/network/mainframe{
-	initial_network_id = "bearnet"
+/obj/machinery/network/relay{
+	initial_network_id = "scavnet"
 	},
 /turf/simulated/floor/bluegrid,
 /area/ship/trade/comms)

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -277,7 +277,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ds" = (
-/obj/machinery/network/relay,
+/obj/machinery/network/router{
+	initial_network_id = "scavnet"
+	},
 /turf/simulated/floor/bluegrid,
 /area/ship/trade/comms)
 "eX" = (
@@ -1136,7 +1138,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "Tx" = (
-/obj/machinery/network/mainframe,
+/obj/machinery/network/mainframe{
+	initial_network_id = "scavnet"
+	},
 /turf/simulated/floor/bluegrid,
 /area/ship/trade/comms)
 "Ua" = (


### PR DESCRIPTION
* Fixes #456 (Captain and F. Mate not having access)
* Tidies up network machines a bit to provide actual coverage
* (Currently machines may still need manual network connecting due to non-map bug)

Should specify with machines:
Router and mainframe are in telecomms now.
Relays in F. Mate office, spooky's grand archives, tool storage
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->