### PR TITLE
Ministation map tweaks

### DIFF
--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -1316,6 +1316,10 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
+/obj/machinery/light{
+	icon_state = "tube_map";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "dk" = (
@@ -3560,18 +3564,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
-"hU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	icon_state = "tube_map";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/ministation/hall/n)
 "hV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -4268,7 +4260,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/ministation/cargo)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4309,14 +4301,17 @@
 /area/ministation/commons)
 "jD" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "jE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/fabricator/book,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "jF" = (
@@ -4787,6 +4782,9 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/insulated/cheap,
+/obj/item/clothing/gloves/insulated/cheap,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "kG" = (
@@ -5285,6 +5283,9 @@
 /turf/simulated/floor/holofloor/lino,
 /area/ministation/commons)
 "lV" = (
+/obj/structure/closet/medical_wall/ministation{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "lW" = (
@@ -5292,6 +5293,7 @@
 	icon_state = "computer";
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "lX" = (
@@ -5301,7 +5303,6 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/ministation/commons)
 "lY" = (
@@ -5476,7 +5477,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/e)
 "mw" = (
-/obj/machinery/vending/assist,
+/obj/machinery/vending/assist/ministation,
 /turf/simulated/floor/plating,
 /area/ministation/maint/e)
 "mx" = (
@@ -6715,6 +6716,11 @@
 "pv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
 "pw" = (
@@ -7599,7 +7605,7 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/w)
 "rz" = (
-/obj/machinery/vending/assist{
+/obj/machinery/vending/assist/ministation{
 	icon_state = "generic";
 	dir = 1
 	},
@@ -7608,6 +7614,9 @@
 "rA" = (
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s)
@@ -9011,16 +9020,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/medical)
-"uz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ministation/medical)
 "uA" = (
 /obj/machinery/network/mainframe{
 	initial_network_id = "zebranet"
@@ -9173,6 +9172,9 @@
 "uX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	icon_state = "map_vent_out";
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10805,7 +10807,6 @@
 /turf/simulated/floor/shuttle/blue,
 /area/ministation/arrival_shuttle)
 "yR" = (
-/obj/machinery/computer/arcade/orion_trail,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
@@ -16000,6 +16001,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
+"MB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/s)
 "MD" = (
 /obj/item/stool/padded,
 /obj/structure/sign/warning/nosmoking_2{
@@ -16038,6 +16046,10 @@
 /obj/item/bedsheet/green,
 /turf/simulated/floor/tiled,
 /area/ministation/yinglet_rep)
+"OS" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/shuttle/blue,
+/area/ministation/arrival_shuttle)
 "OW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16055,6 +16067,13 @@
 	dir = 1;
 	pixel_x = -32;
 	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/s)
+"Pa" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s)
@@ -16097,6 +16116,10 @@
 /obj/structure/sign/botany,
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
+"QB" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/e)
 "QP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
@@ -16136,6 +16159,10 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/floor/plating,
 /area/ministation/hall/w)
+"Sj" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16166,6 +16193,13 @@
 	},
 /turf/simulated/floor/shuttle/blue,
 /area/ministation/arrival_shuttle)
+"TC" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "Un" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -16216,6 +16250,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"Wr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "WQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16293,6 +16334,15 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
+"Yo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/e)
 "Yv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16320,6 +16370,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s)
+"ZE" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/commons)
 "ZI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -16342,6 +16401,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
+"ZY" = (
+/obj/structure/cryofeed{
+	icon_state = "cryo_rear";
+	dir = 4
+	},
+/turf/simulated/floor/shuttle/blue,
+/area/ministation/arrival_shuttle)
 
 (1,1,1) = {"
 aa
@@ -41940,7 +42006,7 @@ kZ
 kZ
 kZ
 yi
-yj
+OS
 zo
 zo
 zo
@@ -43998,7 +44064,7 @@ mP
 ei
 yS
 WX
-WX
+ZY
 WX
 yS
 yk
@@ -47565,11 +47631,11 @@ fw
 fw
 gu
 gQ
-gQ
+Sj
 di
 iq
 ir
-kd
+ZE
 kd
 kd
 kd
@@ -47822,7 +47888,7 @@ fx
 fx
 gv
 gQ
-gQ
+TC
 di
 di
 iX
@@ -48337,10 +48403,10 @@ fz
 fz
 gR
 fz
-hU
-fz
-fz
 Md
+fz
+fz
+fz
 NR
 kL
 gQ
@@ -48353,8 +48419,8 @@ aV
 aV
 aV
 aV
-aV
 Mc
+aV
 OW
 tu
 Nh
@@ -48368,7 +48434,7 @@ aV
 aV
 aV
 aV
-aV
+Pa
 wf
 zA
 uh
@@ -48849,7 +48915,7 @@ eP
 fB
 fU
 gy
-gT
+Wr
 gT
 hV
 gT
@@ -48873,7 +48939,7 @@ Yv
 tw
 ui
 ui
-ui
+MB
 wg
 aV
 aV
@@ -50156,7 +50222,7 @@ rB
 nl
 sH
 tz
-ty
+QB
 bj
 vt
 wk
@@ -54009,7 +54075,7 @@ qo
 qY
 rI
 oz
-sQ
+Yo
 tG
 um
 uS
@@ -57609,7 +57675,7 @@ rR
 sq
 sZ
 oz
-uz
+uy
 uZ
 vM
 oz

--- a/maps/ministation/ministation_objects.dm
+++ b/maps/ministation/ministation_objects.dm
@@ -20,10 +20,10 @@
 	storage_types = CLOSET_STORAGE_MOBS | CLOSET_STORAGE_ITEMS
 
 //suit cyclers
-/obj/machinery/suit_cycler/ministation
+/obj/machinery/suit_cycler/ministation //this one goes in eva
 	req_access = list()
-	suit = /obj/item/clothing/suit/space/emergency
-	helmet = /obj/item/clothing/head/helmet/space/emergency
+	suit = /obj/item/clothing/suit/space
+	helmet = /obj/item/clothing/head/helmet/space
 
 /obj/machinery/suit_cycler/engineering/ministation
 	suit = /obj/item/clothing/suit/space/void/engineering
@@ -34,3 +34,12 @@
 	suit = /obj/item/clothing/suit/space/void/mining
 	helmet = /obj/item/clothing/head/helmet/space/void/mining
 	boots = /obj/item/clothing/shoes/magboots
+
+/obj/structure/closet/medical_wall/ministation/WillContain() // for common area, has slightly less than normal
+	return list(
+		/obj/random/firstaid,
+		/obj/random/medical/lite = 8)
+
+/obj/machinery/vending/assist/ministation/Initialize() //vending machines found in maint tunnels
+	. = ..()
+	contraband += list(/obj/item/multitool = 1)


### PR DESCRIPTION
* Adds randomized medical supplies to commons
* Adds two budget insulated gloves to commons
* Assistant vending machines have multitool as contraband
* Replaced emergency space suits in EVA with real space suits
* Fixes maint access to cargo

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.
-->