### PR TITLE
Fixes/tweaks

### DIFF
--- a/code/modules/client/preference_setup/background/01_culture.dm
+++ b/code/modules/client/preference_setup/background/01_culture.dm
@@ -68,7 +68,7 @@
 		if(check)
 			pref.real_name = check.sanitize_name(pref.real_name, pref.species)
 			if(!pref.real_name)
-				pref.real_name = random_name(pref.gender, pref.species)
+				pref.real_name = check.get_random_name(preference_mob(), pref.gender)
 
 /datum/category_item/player_setup_item/background/culture/load_character(var/savefile/S)
 	for(var/token in tokens)

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -67,7 +67,7 @@ datum/preferences
 				return TOPIC_NOACTION
 
 	else if(href_list["random_name"])
-		pref.real_name = random_name(pref.gender, pref.species)
+		pref.real_name = pref.get_random_name()
 		return TOPIC_REFRESH
 
 	else if(href_list["always_random_name"])

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -110,6 +110,11 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	pref.f_style		= sanitize_inlist(pref.f_style, GLOB.facial_hair_styles_list, initial(pref.f_style))
 	pref.b_type			= sanitize_text(pref.b_type, initial(pref.b_type))
 
+	// Grandfather clause for loading old saves.
+	if(lowertext(pref.species) == "southern yinglet")
+		pref.species = "Yinglet"
+	// End grandfather clause.
+
 	if(!pref.species || !(pref.species in get_playable_species()))
 		pref.species = GLOB.using_map.default_species
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -69,7 +69,7 @@ var/list/time_prefs_fixed = list()
 		GET_DECL(/decl/hierarchy/skill)
 	player_setup = new(src)
 	gender = pick(MALE, FEMALE)
-	real_name = random_name(gender,species)
+	real_name = get_random_name()
 	b_type = RANDOM_BLOOD_TYPE
 
 	if(client && !IsGuestKey(client.key))

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -14,6 +14,11 @@
 	var/list/autohiss_extra_map = null
 	var/list/autohiss_exempt = null
 
+/decl/species/proc/get_autohiss_map()
+	. = autohiss_basic_map?.Copy() || list()
+	if(mode == GLOB.PREF_FULL && autohiss_extra_map)
+		. |= autohiss_extra_map
+
 /decl/species/proc/handle_autohiss(message, decl/language/lang, mode)
 	if(!autohiss_basic_map)
 		return message
@@ -22,10 +27,7 @@
 	if(autohiss_exempt && (lang.name in autohiss_exempt))
 		return message
 
-	var/map = autohiss_basic_map.Copy()
-	if(mode == GLOB.PREF_FULL && autohiss_extra_map)
-		map |= autohiss_extra_map
-
+	var/map = get_autohiss_map(mode)
 	. = list()
 
 	while(length(message))

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -14,7 +14,7 @@
 	var/list/autohiss_extra_map = null
 	var/list/autohiss_exempt = null
 
-/decl/species/proc/get_autohiss_map()
+/decl/species/proc/get_autohiss_map(var/mode)
 	. = autohiss_basic_map?.Copy() || list()
 	if(mode == GLOB.PREF_FULL && autohiss_extra_map)
 		. |= autohiss_extra_map

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -151,7 +151,8 @@
 			qdel(mannequin)
 
 			if(client.prefs.be_random_name)
-				client.prefs.real_name = random_name(client.prefs.gender)
+				client.prefs.real_name = client.prefs.get_random_name()
+
 			observer.real_name = client.prefs.real_name
 			observer.SetName(observer.real_name)
 			if(!client.holder && !config.antag_hud_allowed)           // For new ghosts we remove the verb from even showing up if it's not allowed.
@@ -440,7 +441,7 @@
 
 	if(GLOB.random_players)
 		client.prefs.gender = pick(MALE, FEMALE)
-		client.prefs.real_name = random_name(new_character.gender)
+		client.prefs.real_name = client.prefs.get_random_name()
 		client.prefs.randomize_appearance_and_body_for(new_character)
 	client.prefs.copy_to(new_character)
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -92,3 +92,11 @@
 	dress_preview_mob(mannequin)
 
 	update_character_previews(new /mutable_appearance(mannequin))
+
+/datum/preferences/proc/get_random_name()
+	var/decl/cultural_info/culture/check_culture = cultural_info[TAG_CULTURE]
+	if(ispath(check_culture, /decl/cultural_info))
+		check_culture = GET_DECL(check_culture)
+		real_name = check_culture.get_random_name(client?.mob, gender)
+	else
+		real_name = random_name(gender, species)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -97,6 +97,6 @@
 	var/decl/cultural_info/culture/check_culture = cultural_info[TAG_CULTURE]
 	if(ispath(check_culture, /decl/cultural_info))
 		check_culture = GET_DECL(check_culture)
-		real_name = check_culture.get_random_name(client?.mob, gender)
+		return check_culture.get_random_name(client?.mob, gender)
 	else
-		real_name = random_name(gender, species)
+		return random_name(gender, species)

--- a/maps/ministation/ministation_jobs.dm
+++ b/maps/ministation/ministation_jobs.dm
@@ -31,18 +31,5 @@
 			/datum/job/ministation/scientist,
 			/datum/job/ministation/security,
 			/datum/job/yinglet/yinglet_rep
-		),
-		/decl/species/yinglet/southern = list(
-			/datum/job/assistant,
-			/datum/job/ministation/bartender,
-			/datum/job/ministation/cargo,
-			/datum/job/cyborg,
-			/datum/job/ministation/detective,
-			/datum/job/ministation/doctor,
-			/datum/job/ministation/engineer,
-			/datum/job/ministation/janitor,
-			/datum/job/ministation/scientist,
-			/datum/job/ministation/security,
-			/datum/job/yinglet/yinglet_rep
 		)
 	)

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -1692,7 +1692,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure engineering voidsuit locker";
-	req_access = list("ACCESS_CHIEF_ENGINEER")
+	req_access = list("ACCESS_ENGINE_EQUIP")
 	},
 /obj/item/clothing/head/helmet/space/void/engineering/salvage,
 /obj/item/clothing/suit/space/void/engineering/salvage,

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -42,16 +42,5 @@
 			/datum/job/cyborg,
 			/datum/job/tradeship_doctor,
 			/datum/job/tradeship_researcher
-		),
-		/decl/species/yinglet/southern = list(
-			/datum/job/yinglet/worker,
-			/datum/job/yinglet/scout,
-			/datum/job/yinglet/patriarch,
-			/datum/job/yinglet/matriarch,
-			/datum/job/assistant,
-			/datum/job/tradeship_engineer,
-			/datum/job/cyborg,
-			/datum/job/tradeship_doctor,
-			/datum/job/tradeship_researcher
 		)
 	)

--- a/mods/valsalia/map/culture.dm
+++ b/mods/valsalia/map/culture.dm
@@ -66,8 +66,9 @@
 
 /decl/cultural_info/culture/yinglet/tribal
 	name = "Tribal Yinglet"
-	description = "You are a member of one of the southern yinglet tribes. Tribal yinglets tend to be more \
-	uneducated and rather less quick on the uptake than their cosmopolitan northern cousins."
+	description = "You are a member of one of the southern yinglet tribes. Although similar to the other \
+	clam-loving rat-birds of the yinglet species, the southern yinglets are more parochial, tribal and \
+	generally less developed. Nobody is quite clear on which south they are from."
 	// Names provided by esteemed wordsmith Val Salia.
 	// Jesus Christ, Val.
 	var/list/all_scav_names = list(

--- a/mods/valsalia/species/yinglet.dm
+++ b/mods/valsalia/species/yinglet.dm
@@ -133,8 +133,8 @@
 	equip_adjust = list(
 		slot_undershirt_str = list(
 			"[NORTH]" = list("x" =  0, "y" = -3),
-			"[EAST]" =  list("x" =  3, "y" = -3),
-			"[WEST]" =  list("x" = -3, "y" = -3),
+			"[EAST]" =  list("x" =  1, "y" = -3),
+			"[WEST]" =  list("x" = -1, "y" = -3),
 			"[SOUTH]" = list("x" =  0, "y" = -3)
 		),
 		slot_head_str = list(

--- a/mods/valsalia/species/yinglet.dm
+++ b/mods/valsalia/species/yinglet.dm
@@ -79,6 +79,7 @@
 	available_cultural_info = list(
 		TAG_CULTURE =   list(
 			/decl/cultural_info/culture/yinglet,
+			/decl/cultural_info/culture/yinglet/tribal,
 			/decl/cultural_info/culture/other
 		),
 		TAG_HOMEWORLD = list(
@@ -119,29 +120,35 @@
 
 /decl/species/yinglet/New()
 	equip_adjust = list(
-		slot_head_str = list(
-			"[NORTH]" = list("x" = 0,  "y" = -3),
-			"[EAST]" =  list("x" = 3,  "y" = -3),
+		slot_undershirt_str = list(
+			"[NORTH]" = list("x" =  0, "y" = -3),
+			"[EAST]" =  list("x" =  3, "y" = -3),
 			"[WEST]" =  list("x" = -3, "y" = -3),
-			"[SOUTH]" = list("x" = 0,  "y" = -3)
+			"[SOUTH]" = list("x" =  0, "y" = -3)
+		),
+		slot_head_str = list(
+			"[NORTH]" = list("x" =  0, "y" = -3),
+			"[EAST]" =  list("x" =  3, "y" = -3),
+			"[WEST]" =  list("x" = -3, "y" = -3),
+			"[SOUTH]" = list("x" =  0, "y" = -3)
 		),
 		slot_back_str = list(
-			"[NORTH]" = list("x" = 0,  "y" = -5),
-			"[EAST]" =  list("x" = 3,  "y" = -5),
+			"[NORTH]" = list("x" =  0, "y" = -5),
+			"[EAST]" =  list("x" =  3, "y" = -5),
 			"[WEST]" =  list("x" = -3, "y" = -5),
-			"[SOUTH]" = list("x" = 0,  "y" = -5)
+			"[SOUTH]" = list("x" =  0, "y" = -5)
 		),
 		slot_belt_str = list(
-			"[NORTH]" = list("x" = 0,  "y" = -1),
-			"[EAST]" =  list("x" = 2,  "y" = -1),
+			"[NORTH]" = list("x" =  0, "y" = -1),
+			"[EAST]" =  list("x" =  2, "y" = -1),
 			"[WEST]" =  list("x" = -2, "y" = -1),
-			"[SOUTH]" = list("x" = 0,  "y" = -1)
+			"[SOUTH]" = list("x" =  0, "y" = -1)
 		),
 		slot_glasses_str = list(
-			"[NORTH]" = list("x" = 0,  "y" = -3),
-			"[EAST]" =  list("x" = 2,  "y" = -3),
+			"[NORTH]" = list("x" =  0, "y" = -3),
+			"[EAST]" =  list("x" =  2, "y" = -3),
 			"[WEST]" =  list("x" = -2, "y" = -3),
-			"[SOUTH]" = list("x" = 0,  "y" = -3)
+			"[SOUTH]" = list("x" =  0, "y" = -3)
 		),
 		BP_L_HAND = list(
 			"[NORTH]" = list("x" = 2,  "y" = -3),
@@ -151,15 +158,15 @@
 		),
 		BP_R_HAND = list(
 			"[NORTH]" = list("x" = -2, "y" = -3),
-			"[EAST]" =  list("x" = 2,  "y" = -3),
+			"[EAST]" =  list("x" =  2, "y" = -3),
 			"[WEST]" =  list("x" = -2, "y" = -3),
-			"[SOUTH]" = list("x" = 2,  "y" = -3)
+			"[SOUTH]" = list("x" =  2, "y" = -3)
 		),
 		slot_wear_mask_str = list(
-			"[NORTH]" = list("x" = 0,  "y" = -3),
-			"[EAST]" =  list("x" = 2,  "y" = -3),
+			"[NORTH]" = list("x" =  0, "y" = -3),
+			"[EAST]" =  list("x" =  2, "y" = -3),
 			"[WEST]" =  list("x" = -2, "y" = -3),
-			"[SOUTH]" = list("x" = 0,  "y" = -3)
+			"[SOUTH]" = list("x" =  0, "y" = -3)
 		)
 	)
 	..()

--- a/mods/valsalia/species/yinglet.dm
+++ b/mods/valsalia/species/yinglet.dm
@@ -8,6 +8,9 @@
 	autohiss_basic_map = list(
 		"th" = list("z")
 	)
+	autohiss_extra_map = list(
+		"th" = list("d")
+	)
 
 	icobase =         'mods/valsalia/icons/species/yinglet/body.dmi'
 	deform =          'mods/valsalia/icons/species/yinglet/deformed_body.dmi'
@@ -118,6 +121,14 @@
 		pref.body_markings["Shelltooth"] = "#cccccc"
 	pref.skin_colour = "#787878"
 
+/decl/species/yinglet/get_autohiss_map(var/mode)
+	if(mode == GLOB.PREF_FULL)
+		. = autohiss_extra_map?.Copy()
+	else
+		. = autohiss_basic_map?.Copy()
+	if(!islist(.))
+		. = list()
+
 /decl/species/yinglet/New()
 	equip_adjust = list(
 		slot_undershirt_str = list(
@@ -170,34 +181,6 @@
 		)
 	)
 	..()
-
-// This is honestly just so the other name generator becomes available.
-/decl/species/yinglet/southern
-	name = SPECIES_YINGLET_SOUTHERN
-	name_plural = "Southern Yinglets"
-	description = "Although similar to the other clam-loving rat-birds of the yinglet species, the southern \
-	yinglets are more parochial, tribal and generally less developed. Nobody is quite clear on which south \
-	they are from."
-	autohiss_basic_map = list(
-		"th" = list("d")
-	)
-
-	available_cultural_info = list(
-		TAG_CULTURE =   list(
-			/decl/cultural_info/culture/yinglet/tribal,
-			/decl/cultural_info/culture/other
-		),
-		TAG_HOMEWORLD = list(
-			/decl/cultural_info/location/stateless
-		),
-		TAG_FACTION =   list(
-			/decl/cultural_info/faction/enclave_ying,
-			/decl/cultural_info/faction/other
-		),
-		TAG_RELIGION =  list(
-			/decl/cultural_info/religion/other
-		)
-	)
 
 /obj/item/holder/yinglet
 	sharp = 1

--- a/mods/valsalia/species/yinglet_accessories.dm
+++ b/mods/valsalia/species/yinglet_accessories.dm
@@ -1,7 +1,7 @@
 /datum/sprite_accessory/marking/yinglet
 	name = "Shelltooth"
 	body_parts = list(BP_HEAD)
-	species_allowed = list(SPECIES_YINGLET, SPECIES_YINGLET_SOUTHERN)
+	species_allowed = list(SPECIES_YINGLET)
 	icon = 'mods/valsalia/icons/species/yinglet/markings.dmi'
 	icon_state = "shelltooth"
 	blend = ICON_MULTIPLY
@@ -59,7 +59,7 @@
 /datum/sprite_accessory/hair/yinglet
 	name = "Ying Messy"
 	icon_state = "hair_messy"
-	species_allowed = list(SPECIES_YINGLET, SPECIES_YINGLET_SOUTHERN)
+	species_allowed = list(SPECIES_YINGLET)
 	icon = 'mods/valsalia/icons/species/yinglet/hair.dmi'
 	blend = ICON_MULTIPLY
 

--- a/mods/valsalia/valsalia.dm
+++ b/mods/valsalia/valsalia.dm
@@ -1,7 +1,6 @@
 #define SPECIES_BAXXID           "Baxxid"
 #define SPECIES_INDREL           "Indrel"
 #define SPECIES_YINGLET          "Yinglet"
-#define SPECIES_YINGLET_SOUTHERN "Southern Yinglet"
 #define IS_YINGLET               "yinglet"
 #define BODYTYPE_YINGLET         "yinglet body"
 #define BODYTYPE_BAXXID          "baxxid body"


### PR DESCRIPTION
:cl:
tweak: Southern Yinglet species has been collapsed into the base species, select the 'Tribal Yinglet' culture in the background tab to get access to the southern yinglet namegen. You might need to reselect your species and apply customization again after this change, apologies.
tweak: Scav autohiss now has two modes: basic will do `th => z`, full will do `th => d`. You might need to toggle it if you were using full previously.
tweak: Scavs can wear undershirts without it looking quite as absurd. Still pretty absurd though.
tweak: Junior Engineers can access the voidsuit locker.
/:cl:

- Fixes #550
- Fixes #531