### PR TITLE
libera thruster changes

### DIFF
--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -134,6 +134,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction/mirrored,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "as" = (
@@ -251,11 +252,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 7;
-	pixel_y = 4
-	},
+/obj/machinery/computer/ship/engines,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "aF" = (
@@ -312,33 +309,22 @@
 /turf/simulated/floor/plating,
 /area/liberia/merchantstorage)
 "aK" = (
-/obj/structure/cable/blue{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
-/obj/machinery/ion_thruster{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/liberia/engineeringengines)
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/captain)
 "aM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
 	},
-/obj/structure/closet/emcloset{
-	anchored = 1;
-	name = "anchored emergency closet"
-	},
+/obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "aN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
-/obj/structure/table,
-/obj/item/rcd,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
-/obj/item/rcd_ammo/large,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "aO" = (
@@ -409,6 +395,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "aW" = (
@@ -466,6 +453,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "bb" = (
@@ -500,6 +490,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
@@ -713,10 +706,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberia/mule)
 "bt" = (
-/obj/structure/closet/secure_closet{
-	name = "merchant's locker";
-	req_access = list("ACCESS_MERCHANT")
-	},
 /obj/effect/floor_decal/corner/brown/half,
 /obj/machinery/power/apc/liberia{
 	dir = 1;
@@ -726,6 +715,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/unary/tank/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberia/mule)
 "bu" = (
@@ -794,14 +784,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "by" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 5
+/obj/effect/paint/silver,
+/obj/effect/paint_stripe/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
-/obj/structure/table,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/wall/r_titanium,
 /area/liberia/mule)
 "bz" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -997,9 +985,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/blue{
-	icon_state = "2-4"
-	},
+/obj/machinery/atmospherics/valve/open,
 /turf/simulated/floor/tiled/dark,
 /area/liberia/mule)
 "bR" = (
@@ -1008,9 +994,6 @@
 	req_access = newlist()
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberia/mule)
 "bS" = (
@@ -1018,9 +1001,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/liberia/mule)
 "bT" = (
@@ -1029,9 +1009,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
-	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/mule)
@@ -1054,9 +1031,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
 /area/liberia/mule)
 "bW" = (
@@ -1206,6 +1181,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "cj" = (
@@ -1267,6 +1243,9 @@
 	dir = 4
 	},
 /obj/item/taperecorder,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberia/mule)
 "cp" = (
@@ -1291,6 +1270,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/mule)
 "cq" = (
@@ -1304,6 +1286,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/liberia/mule)
 "cr" = (
@@ -1314,6 +1299,9 @@
 	dir = 9
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/mule)
 "cs" = (
@@ -1331,6 +1319,9 @@
 	dir = 10
 	},
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "ct" = (
@@ -1345,6 +1336,9 @@
 	},
 /obj/item/clothing/mask/gas,
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "cu" = (
@@ -1358,9 +1352,6 @@
 	dir = 5
 	},
 /obj/structure/table,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "cv" = (
@@ -1475,6 +1466,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/unary/tank/carbon_dioxide,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringengines)
 "cG" = (
@@ -1662,6 +1654,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/valve/open,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "cZ" = (
@@ -1743,9 +1736,7 @@
 /turf/simulated/floor/plating,
 /area/liberia/mule)
 "dh" = (
-/obj/machinery/computer/ship/engines{
-	dir = 4
-	},
+/obj/machinery/computer/ship/engines,
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = null
@@ -1835,6 +1826,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "do" = (
@@ -1985,6 +1977,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "dA" = (
@@ -2001,6 +1996,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "dB" = (
@@ -2009,6 +2007,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "dC" = (
@@ -2163,6 +2162,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "dP" = (
@@ -2215,6 +2217,9 @@
 /obj/effect/catwalk_plated,
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
@@ -2269,6 +2274,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "dW" = (
@@ -2286,6 +2294,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment/bent,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "dX" = (
@@ -2312,9 +2323,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "ea" = (
@@ -2327,8 +2336,8 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
@@ -2422,6 +2431,7 @@
 	},
 /obj/item/binoculars,
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "eh" = (
@@ -2430,9 +2440,6 @@
 	},
 /obj/item/instrument/guitar,
 /obj/structure/table,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "ej" = (
@@ -2472,6 +2479,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "en" = (
@@ -2885,6 +2893,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "fa" = (
@@ -3209,6 +3220,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "fF" = (
@@ -3402,6 +3414,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "fZ" = (
@@ -3618,6 +3631,9 @@
 /obj/structure/cable/blue{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gv" = (
@@ -3628,6 +3644,9 @@
 /obj/effect/floor_decal/spline/plain/brown,
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
@@ -3645,6 +3664,9 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gx" = (
@@ -3659,6 +3681,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gy" = (
@@ -3671,6 +3696,9 @@
 	dir = 4
 	},
 /obj/item/clothing/mask/smokable/cigarette/cigar/havana,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gz" = (
@@ -3683,6 +3711,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment/bent{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
@@ -3698,6 +3729,9 @@
 	dir = 4
 	},
 /obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/bar)
 "gC" = (
@@ -3713,6 +3747,9 @@
 /obj/effect/catwalk_plated,
 /obj/structure/cable/blue{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
@@ -3865,9 +3902,6 @@
 /obj/structure/cable/blue{
 	icon_state = "0-4"
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
 "gP" = (
@@ -3882,6 +3916,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
@@ -3904,6 +3941,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
@@ -3931,6 +3971,9 @@
 /obj/structure/cable/blue{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
 "gT" = (
@@ -3942,6 +3985,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -3955,6 +4001,9 @@
 /obj/machinery/light,
 /obj/structure/cable/blue{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -4045,15 +4094,15 @@
 	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/item/folder,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
 "hh" = (
 /obj/effect/floor_decal/spline/plain/brown,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
@@ -4063,6 +4112,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/brown,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
 "hj" = (
@@ -4198,7 +4250,7 @@
 "hz" = (
 /obj/machinery/vending/cigarette{
 	dir = 1;
-	products = list(/obj/item/storage/fancy/cigarettes = 10, /obj/item/storage/box/matches = 10, /obj/item/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/storage/fancy/cigarettes=10,/obj/item/storage/box/matches=10,/obj/item/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -4417,12 +4469,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/random/tool,
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "ic" = (
@@ -4504,6 +4551,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "ii" = (
@@ -4525,6 +4575,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "ij" = (
@@ -4557,6 +4610,14 @@
 	pixel_x = 7;
 	pixel_y = 4
 	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/rcd,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/engineeringreactor)
 "ip" = (
@@ -5269,14 +5330,11 @@
 /turf/simulated/floor/carpet,
 /area/liberia/library)
 "kf" = (
-/obj/machinery/ion_thruster{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/liberia/mule)
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/engineeringengines)
 "kg" = (
 /obj/machinery/door/airlock/civilian{
 	id_tag = "merchdorm1";
@@ -5551,6 +5609,9 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "kG" = (
@@ -5616,6 +5677,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "kQ" = (
@@ -5657,6 +5719,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "kU" = (
@@ -5688,6 +5751,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "kX" = (
@@ -6130,6 +6194,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "mr" = (
@@ -6202,6 +6267,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -6340,33 +6408,17 @@
 /turf/simulated/wall/prepainted,
 /area/liberia/toiletroom1)
 "pE" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/green{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/liberia/mule)
-"pF" = (
-/obj/structure/cable/blue,
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/obj/machinery/ion_thruster{
-	dir = 4
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/airless,
+/turf/simulated/wall/r_wall/prepainted,
 /area/liberia/captain)
+"pF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/engineeringengines)
 "pJ" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -6385,6 +6437,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
@@ -6415,6 +6470,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "pX" = (
@@ -6438,9 +6496,6 @@
 /turf/simulated/floor/carpet/red,
 /area/liberia/traidingroom)
 "qc" = (
-/obj/machinery/atm{
-	pixel_y = -30
-	},
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = null
@@ -6449,6 +6504,9 @@
 	req_access = newlist()
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atm{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "qg" = (
@@ -6476,6 +6534,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "qo" = (
@@ -6566,6 +6625,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "rx" = (
@@ -6635,6 +6697,9 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "ss" = (
@@ -6647,14 +6712,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/merchantstorage)
-"sA" = (
-/obj/effect/paint/silver,
-/obj/effect/paint_stripe/yellow,
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_titanium,
-/area/liberia/mule)
 "sF" = (
 /obj/machinery/door/airlock/civilian{
 	id_tag = "merchdorm2";
@@ -6795,12 +6852,13 @@
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "tG" = (
-/obj/structure/cable/blue,
-/obj/machinery/ion_thruster{
-	dir = 4
+/obj/effect/paint/silver,
+/obj/effect/paint_stripe/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
-/turf/simulated/floor/airless,
-/area/liberia/engineeringengines)
+/turf/simulated/wall/r_titanium,
+/area/liberia/mule)
 "tI" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -6860,21 +6918,22 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "ur" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/guestroom1)
 "uS" = (
-/obj/structure/cable/blue,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
 /obj/structure/cable/blue{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/ion_thruster{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/liberia/engineeringengines)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/liberia/mule)
 "vd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -6980,11 +7039,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/dockinghall)
 "xx" = (
-/obj/structure/cable/blue,
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/obj/machinery/ion_thruster{
+/obj/machinery/atmospherics/unary/engine{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -7194,6 +7249,9 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/engineeringlobby)
 "Br" = (
@@ -7201,14 +7259,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/atmos)
 "Bx" = (
-/obj/structure/cable/blue,
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
-	},
-/obj/machinery/ion_thruster{
+/obj/machinery/atmospherics/unary/engine{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -7254,9 +7305,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "BX" = (
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/engineeringengines)
 "Dl" = (
@@ -7311,6 +7360,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "Ei" = (
@@ -7365,8 +7415,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/random/coin,
+/obj/machinery/atmospherics/valve/open,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "EG" = (
@@ -7479,12 +7528,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled,
 /area/liberia/mule)
 "GE" = (
@@ -7500,6 +7543,7 @@
 /obj/structure/cable/blue{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "GG" = (
@@ -7652,16 +7696,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/liberia/merchantstorage)
 "Iq" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "Iw" = (
 /turf/simulated/wall/prepainted,
@@ -7686,10 +7726,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "IM" = (
-/obj/machinery/ion_thruster{
+/obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/obj/structure/cable/blue,
 /turf/simulated/floor/plating,
 /area/liberia/mule)
 "IQ" = (
@@ -7795,16 +7834,13 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/liberia/engineeringlobby)
 "KF" = (
-/obj/structure/cable/blue,
-/obj/machinery/ion_thruster{
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/wall/r_wall/prepainted,
 /area/liberia/captain)
 "KH" = (
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/captain)
 "Lh" = (
@@ -7943,6 +7979,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "NK" = (
@@ -8015,6 +8052,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
@@ -8169,12 +8209,11 @@
 /turf/simulated/wall/prepainted,
 /area/liberia/cryo)
 "Sb" = (
-/obj/effect/floor_decal/spline/plain/brown,
-/obj/structure/cable/blue{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
-/turf/simulated/floor/wood/ebony,
-/area/liberia/captain)
+/turf/simulated/wall/r_wall/prepainted,
+/area/liberia/engineeringengines)
 "Se" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/liberia/toiletroom1)
@@ -8292,6 +8331,9 @@
 /obj/structure/cable/blue{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "TT" = (
@@ -8303,6 +8345,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
@@ -8472,17 +8517,17 @@
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment/bent,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "WS" = (
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
-/obj/machinery/ion_thruster{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/liberia/captain)
+/obj/effect/paint/silver,
+/obj/effect/paint_stripe/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/r_titanium,
+/area/liberia/mule)
 "WW" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -8534,6 +8579,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "Yt" = (
@@ -24494,7 +24540,7 @@ aa
 aa
 ex
 bw
-pE
+bU
 cs
 cU
 bw
@@ -24693,15 +24739,15 @@ VX
 aa
 aa
 aa
-ex
-ex
-bx
+by
+WS
+Iq
 bV
 ct
-cV
+uS
 eg
-ex
-ex
+WS
+tG
 aa
 oM
 ZO
@@ -24895,14 +24941,14 @@ VX
 aa
 aa
 aa
-kf
-sA
-by
+IM
+ex
+bx
 Gz
 cu
-Iq
+cV
 eh
-sA
+ex
 IM
 aa
 oM
@@ -25083,10 +25129,10 @@ aa
 aa
 aa
 iy
-aK
-uS
 Bx
-tG
+Bx
+Bx
+Bx
 iy
 xG
 oM
@@ -25114,10 +25160,10 @@ pS
 VX
 Fc
 Aa
-WS
-pF
 xx
-KF
+xx
+xx
+xx
 Aa
 aa
 aa
@@ -25285,10 +25331,10 @@ aa
 aa
 aa
 iy
-iy
-iy
+pF
+kf
 BX
-iy
+Sb
 iy
 aa
 oM
@@ -25316,10 +25362,10 @@ pS
 VX
 Fc
 Aa
-Aa
+aK
 KH
-Aa
-Aa
+KF
+pE
 Aa
 aa
 aa
@@ -25923,7 +25969,7 @@ VX
 Fc
 Aa
 gO
-Sb
+hh
 no
 hE
 xc


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
swaps ion thrusters with rockets

## Why and what will this PR improve
Ion thrusters are broken, this lets liberia/mule move.

## Authorship
Devcord

## Changelog
:cl:
tweak: thruster types on liberia/mule
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->