### PR TITLE
removes liberia as a guaranteed spawn. tweaks away site weights and c…

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/meat.dm
+++ b/code/modules/overmap/exoplanets/planet_types/meat.dm
@@ -16,7 +16,7 @@
 		/mob/living/simple_animal/hostile/retaliate/jelly/alt,
 		/mob/living/simple_animal/hostile/leech
 	)
-	spawn_weight = 10	// meat
+	spawn_weight = 50	// meat
 
 /obj/effect/overmap/visitable/sector/exoplanet/meat/generate_map()
 	lightlevel = rand(1,7)/10

--- a/maps/away/liberia/liberia.dm
+++ b/maps/away/liberia/liberia.dm
@@ -9,9 +9,9 @@
 	id = "awaysite_liberia"
 	description = "A Merchant ship."
 	suffixes = list("liberia/liberia.dmm")
-	cost = 0.5
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
-	spawn_weight = 50
+	cost = 1
+//	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
+//	spawn_weight = 50
 	area_usage_test_exempted_root_areas = list(/area/liberia)
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/mule

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -31,7 +31,7 @@
 	id = "awaysite_unishi"
 	description = "CTI research ship.."
 	suffixes = list("unishi/unishi-1.dmm", "unishi/unishi-2.dmm", "unishi/unishi-3.dmm")
-	cost = 2
+	cost = 1
 	area_usage_test_exempted_root_areas = list(/area/unishi)
 
 

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -23,7 +23,7 @@
 	id = "awaysite_yach"
 	description = "Tiny movable ship with spiders."
 	suffixes = list("yacht/yacht.dmm")
-	cost = 0.5
+	cost = 1
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Removed excessive weighting and guaranteed spawn flag from libera so its put in the normal away site pool.
gave all away sites a cost = 1 so we'll hopefully actually start seeing all of them in the rotation.
Upped the spawn weight of the meat exoplanet to be the same as shrouded so we'll hopefully actually see it.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Qumefox

## Changelog
:cl:
tweak: spawn weights and costs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->