### PR TITLE
More yingsuits

### DIFF
--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -101,6 +101,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "al" = (
@@ -504,6 +505,14 @@
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/corner/green,
+/obj/machinery/power/apc/liberia{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/blue{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/traidingroom)
 "bf" = (
@@ -532,6 +541,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
+/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/traidingroom)
 "bh" = (
@@ -901,6 +911,9 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 8
 	},
+/obj/structure/cable/blue{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/liberia/traidingroom)
 "bJ" = (
@@ -1187,7 +1200,9 @@
 "cj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/double/glass/maintenance{
-	dir = 8
+	dir = 8;
+	autoset_access = 0;
+	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/monotile,
@@ -1840,7 +1855,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled/monotile,
-/area/liberia/traidingroom)
+/area/liberia/hallway)
 "dp" = (
 /obj/structure/rack,
 /obj/random/maintenance/clean,
@@ -1855,7 +1870,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/liberia/traidingroom)
+/area/liberia/hallway)
 "dq" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -1874,7 +1889,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/liberia/traidingroom)
+/area/liberia/hallway)
 "dr" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -1885,19 +1900,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "ds" = (
-/obj/structure/sign/warning{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 5
 	},
-/obj/effect/floor_decal/corner/green{
-	dir = 9
-	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/liberia/traidingroom)
 "dt" = (
@@ -1962,7 +1972,8 @@
 "dz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance";
-	req_access = newlist()
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -2069,7 +2080,8 @@
 	},
 /obj/machinery/door/airlock/glass/command{
 	name = "Wreckage Site";
-	req_access = newlist()
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/cable/blue{
@@ -2465,6 +2477,8 @@
 	anchored = 1;
 	name = "anchored emergency closet"
 	},
+/obj/item/clothing/suit/space/void/scav/merchant,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "em" = (
@@ -2951,7 +2965,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock{
+	autoset_access = 0;
+	req_access = list("ACCESS_MERCHANT")
+	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
@@ -3239,6 +3256,8 @@
 "fI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/suit/space/void/scav/merchant,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "fJ" = (
@@ -3272,9 +3291,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/folder,
+/obj/machinery/light_switch{
+	pixel_y = 27
+	},
+/obj/machinery/camera/network,
+/obj/machinery/network/acl,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "fM" = (
@@ -3296,9 +3317,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-06"
-	},
+/obj/machinery/network/mainframe,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "fO" = (
@@ -3331,6 +3350,7 @@
 /obj/structure/bed/chair/wood/walnut{
 	dir = 8
 	},
+/obj/machinery/camera/network,
 /turf/simulated/floor/carpet,
 /area/liberia/bar)
 "fR" = (
@@ -3461,7 +3481,8 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/glass/command{
 	name = "Office";
-	req_access = newlist()
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -3549,6 +3570,8 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/suit/space/void/scav/merchant,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gn" = (
@@ -3762,6 +3785,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/suit/space/void/scav/merchant,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gE" = (
@@ -4120,7 +4145,8 @@
 "hj" = (
 /obj/machinery/door/airlock{
 	name = "Merchant Assistants";
-	req_access = newlist()
+	req_access = list("ACCESS_MERCHANT");
+	autoset_access = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4713,7 +4739,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
+	name = "Maintenance";
+	autoset_access = 0;
+	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/warning/fulltile,
@@ -4769,7 +4797,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/liberia/traidingroom)
+/area/liberia/hallway)
 "iL" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -4936,6 +4964,10 @@
 	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
+	},
+/obj/structure/sign/warning{
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
@@ -5176,6 +5208,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/camera/network,
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
 "jO" = (
@@ -5190,10 +5223,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_y = 3
-	},
+/obj/machinery/network/router,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "jR" = (
@@ -5687,6 +5717,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/white,
 /area/liberia/medbay)
 "kR" = (
@@ -6274,11 +6305,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
 "ns" = (
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
-/area/liberia/traidingroom)
+/area/liberia/hallway)
 "nD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -6631,13 +6659,12 @@
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "rx" = (
-/obj/machinery/power/apc/liberia{
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/double/glass/maintenance{
 	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-2"
+	autoset_access = 0;
+	req_access = list("ACCESS_MERCHANT")
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/traidingroom)
@@ -6663,6 +6690,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/suit/space/void/scav/merchant,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "rZ" = (
@@ -7326,19 +7355,6 @@
 /obj/effect/floor_decal/corner/blue/full,
 /turf/simulated/floor/tiled/dark,
 /area/liberia/bridge)
-"DL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/blue{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/liberia/hallway)
 "DP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7681,6 +7697,17 @@
 /area/liberia/bridge)
 "HV" = (
 /turf/simulated/wall/r_wall/prepainted,
+/area/liberia/merchantstorage)
+"Ic" = (
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/rack/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/camera/network,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "Ig" = (
 /obj/machinery/light,
@@ -8292,7 +8319,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
 "Tz" = (
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock{
+	autoset_access = 0;
+	req_access = list("ACCESS_MERCHANT")
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
@@ -29590,7 +29620,7 @@ cj
 Nv
 Nv
 Nv
-Nv
+qx
 dC
 dV
 qx
@@ -30600,7 +30630,7 @@ fF
 Nq
 Nv
 Nv
-Nv
+qx
 dF
 eb
 th
@@ -30788,7 +30818,7 @@ aa
 aa
 HV
 HV
-jV
+Ic
 Aq
 yP
 vd
@@ -30803,7 +30833,7 @@ fF
 fF
 rx
 ns
-DL
+dF
 eb
 JI
 ew

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -101,7 +101,6 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "al" = (
@@ -505,14 +504,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/corner/green,
-/obj/machinery/power/apc/liberia{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/traidingroom)
 "bf" = (
@@ -541,7 +532,6 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/traidingroom)
 "bh" = (
@@ -911,9 +901,6 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 8
 	},
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/liberia/traidingroom)
 "bJ" = (
@@ -1200,9 +1187,7 @@
 "cj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/double/glass/maintenance{
-	dir = 8;
-	autoset_access = 0;
-	req_access = list("ACCESS_MERCHANT")
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/monotile,
@@ -1855,7 +1840,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled/monotile,
-/area/liberia/hallway)
+/area/liberia/traidingroom)
 "dp" = (
 /obj/structure/rack,
 /obj/random/maintenance/clean,
@@ -1870,7 +1855,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/liberia/hallway)
+/area/liberia/traidingroom)
 "dq" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -1889,7 +1874,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/liberia/hallway)
+/area/liberia/traidingroom)
 "dr" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -1900,14 +1885,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringreactor)
 "ds" = (
+/obj/structure/sign/warning{
+	dir = 8;
+	pixel_x = 32
+	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/liberia/traidingroom)
 "dt" = (
@@ -1972,8 +1962,7 @@
 "dz" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance";
-	req_access = list("ACCESS_MERCHANT");
-	autoset_access = 0
+	req_access = newlist()
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -2080,8 +2069,7 @@
 	},
 /obj/machinery/door/airlock/glass/command{
 	name = "Wreckage Site";
-	req_access = list("ACCESS_MERCHANT");
-	autoset_access = 0
+	req_access = newlist()
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/cable/blue{
@@ -2477,8 +2465,6 @@
 	anchored = 1;
 	name = "anchored emergency closet"
 	},
-/obj/item/clothing/suit/space/void/scav/merchant,
-/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "em" = (
@@ -2965,10 +2951,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/machinery/door/airlock{
-	autoset_access = 0;
-	req_access = list("ACCESS_MERCHANT")
-	},
+/obj/machinery/door/airlock,
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
@@ -3256,8 +3239,6 @@
 "fI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/suit/space/void/scav/merchant,
-/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "fJ" = (
@@ -3291,11 +3272,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = 27
-	},
-/obj/machinery/camera/network,
-/obj/machinery/network/acl,
+/obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/item/folder,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "fM" = (
@@ -3317,7 +3296,9 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
-/obj/machinery/network/mainframe,
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-06"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "fO" = (
@@ -3350,7 +3331,6 @@
 /obj/structure/bed/chair/wood/walnut{
 	dir = 8
 	},
-/obj/machinery/camera/network,
 /turf/simulated/floor/carpet,
 /area/liberia/bar)
 "fR" = (
@@ -3481,8 +3461,7 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/glass/command{
 	name = "Office";
-	req_access = list("ACCESS_MERCHANT");
-	autoset_access = 0
+	req_access = newlist()
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -3570,8 +3549,6 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/suit/space/void/scav/merchant,
-/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gn" = (
@@ -3785,8 +3762,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/suit/space/void/scav/merchant,
-/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gE" = (
@@ -4145,8 +4120,7 @@
 "hj" = (
 /obj/machinery/door/airlock{
 	name = "Merchant Assistants";
-	req_access = list("ACCESS_MERCHANT");
-	autoset_access = 0
+	req_access = newlist()
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4739,9 +4713,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	autoset_access = 0;
-	req_access = list("ACCESS_MERCHANT")
+	name = "Maintenance"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/warning/fulltile,
@@ -4797,7 +4769,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/liberia/hallway)
+/area/liberia/traidingroom)
 "iL" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -4964,10 +4936,6 @@
 	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
-	},
-/obj/structure/sign/warning{
-	dir = 8;
-	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
@@ -5208,7 +5176,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/camera/network,
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
 "jO" = (
@@ -5223,7 +5190,10 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/network/router,
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch{
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/officeroom)
 "jR" = (
@@ -5717,7 +5687,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
-/obj/machinery/camera/network,
 /turf/simulated/floor/tiled/white,
 /area/liberia/medbay)
 "kR" = (
@@ -6305,8 +6274,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
 "ns" = (
+/obj/structure/cable/blue{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
-/area/liberia/hallway)
+/area/liberia/traidingroom)
 "nD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -6659,12 +6631,13 @@
 /turf/simulated/floor/plating,
 /area/liberia/hallway)
 "rx" = (
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/double/glass/maintenance{
+/obj/machinery/power/apc/liberia{
 	dir = 8;
-	autoset_access = 0;
-	req_access = list("ACCESS_MERCHANT")
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/blue{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/traidingroom)
@@ -6690,8 +6663,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/suit/space/void/scav/merchant,
-/obj/item/clothing/head/helmet/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "rZ" = (
@@ -7355,6 +7326,19 @@
 /obj/effect/floor_decal/corner/blue/full,
 /turf/simulated/floor/tiled/dark,
 /area/liberia/bridge)
+"DL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/blue{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/blue{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/liberia/hallway)
 "DP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7697,17 +7681,6 @@
 /area/liberia/bridge)
 "HV" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/liberia/merchantstorage)
-"Ic" = (
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/structure/rack/dark,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network,
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "Ig" = (
 /obj/machinery/light,
@@ -8319,10 +8292,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
 "Tz" = (
-/obj/machinery/door/airlock{
-	autoset_access = 0;
-	req_access = list("ACCESS_MERCHANT")
-	},
+/obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/blue{
@@ -29620,7 +29590,7 @@ cj
 Nv
 Nv
 Nv
-qx
+Nv
 dC
 dV
 qx
@@ -30630,7 +30600,7 @@ fF
 Nq
 Nv
 Nv
-qx
+Nv
 dF
 eb
 th
@@ -30818,7 +30788,7 @@ aa
 aa
 HV
 HV
-Ic
+jV
 Aq
 yP
 vd
@@ -30833,7 +30803,7 @@ fF
 fF
 rx
 ns
-dF
+DL
 eb
 JI
 ew

--- a/maps/away/liberia/liberia.dmm
+++ b/maps/away/liberia/liberia.dmm
@@ -2465,6 +2465,8 @@
 	anchored = 1;
 	name = "anchored emergency closet"
 	},
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
+/obj/item/clothing/suit/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "em" = (
@@ -3239,6 +3241,8 @@
 "fI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
+/obj/item/clothing/suit/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "fJ" = (
@@ -3549,6 +3553,8 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
+/obj/item/clothing/suit/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gn" = (
@@ -3762,6 +3768,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
+/obj/item/clothing/suit/space/void/scav/merchant,
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "gE" = (
@@ -6663,6 +6671,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/head/helmet/space/void/scav/merchant,
+/obj/item/clothing/suit/space/void/scav/merchant,
 /turf/simulated/floor/tiled/monotile,
 /area/liberia/hallway)
 "rZ" = (

--- a/maps/away/liberia/liberia_areas.dm
+++ b/maps/away/liberia/liberia_areas.dm
@@ -28,7 +28,6 @@
 /area/liberia/engineeringlobby
 	name = "\improper Liberia - Engineering Lobby"
 	icon_state = "primarystorage"
-	req_access = list(access_merchant)
 
 /area/liberia/engineeringstorage
 	name = "\improper Liberia - Engineering Storage"
@@ -45,27 +44,22 @@
 /area/liberia/personellroom1
 	name = "\improper Liberia - Personell Room 1"
 	icon_state = "dk_yellow"
-	req_access = list(access_merchant)
 
 /area/liberia/personellroom2
 	name = "\improper Liberia - Personell Room 2"
 	icon_state = "purple"
-	req_access = list(access_merchant)
 
 /area/liberia/traidingroom
 	name = "\improper Liberia - Traiding Room"
 	icon_state = "purple"
-	req_access = list(access_merchant)
 
 /area/liberia/bridge
 	name = "\improper Liberia - Bridge"
 	icon_state = "bridge"
-	req_access = list(access_merchant)
 
 /area/liberia/cryo
 	name = "\improper Liberia - Cryo"
 	icon_state = "crew_quarters"
-	req_access = list(access_merchant)
 
 /area/liberia/medbay
 	name = "\improper Liberia - Medbay"
@@ -74,7 +68,6 @@
 /area/liberia/officeroom
 	name = "\improper Liberia - Office Room"
 	icon_state = "observatory"
-	req_access = list(access_merchant)
 
 /area/liberia/toiletroom1
 	name = "\improper Liberia - Shower"
@@ -96,7 +89,6 @@
 /area/liberia/atmos
 	name = "\improper Liberia - Atmos Chamber"
 	icon_state = "atmos"
-	req_access = list(access_merchant)
 
 /area/liberia/mule
 	name = "\improper Mule"

--- a/maps/away/liberia/liberia_areas.dm
+++ b/maps/away/liberia/liberia_areas.dm
@@ -28,6 +28,7 @@
 /area/liberia/engineeringlobby
 	name = "\improper Liberia - Engineering Lobby"
 	icon_state = "primarystorage"
+	req_access = list(access_merchant)
 
 /area/liberia/engineeringstorage
 	name = "\improper Liberia - Engineering Storage"
@@ -44,22 +45,27 @@
 /area/liberia/personellroom1
 	name = "\improper Liberia - Personell Room 1"
 	icon_state = "dk_yellow"
+	req_access = list(access_merchant)
 
 /area/liberia/personellroom2
 	name = "\improper Liberia - Personell Room 2"
 	icon_state = "purple"
+	req_access = list(access_merchant)
 
 /area/liberia/traidingroom
 	name = "\improper Liberia - Traiding Room"
 	icon_state = "purple"
+	req_access = list(access_merchant)
 
 /area/liberia/bridge
 	name = "\improper Liberia - Bridge"
 	icon_state = "bridge"
+	req_access = list(access_merchant)
 
 /area/liberia/cryo
 	name = "\improper Liberia - Cryo"
 	icon_state = "crew_quarters"
+	req_access = list(access_merchant)
 
 /area/liberia/medbay
 	name = "\improper Liberia - Medbay"
@@ -68,6 +74,7 @@
 /area/liberia/officeroom
 	name = "\improper Liberia - Office Room"
 	icon_state = "observatory"
+	req_access = list(access_merchant)
 
 /area/liberia/toiletroom1
 	name = "\improper Liberia - Shower"
@@ -89,6 +96,7 @@
 /area/liberia/atmos
 	name = "\improper Liberia - Atmos Chamber"
 	icon_state = "atmos"
+	req_access = list(access_merchant)
 
 /area/liberia/mule
 	name = "\improper Mule"

--- a/maps/away_sites_testing/away_sites_testing.dm
+++ b/maps/away_sites_testing/away_sites_testing.dm
@@ -20,6 +20,7 @@
 	#include "../away/unishi/unishi.dm"
 	#include "../away/yacht/yacht.dm"
 	#include "../away/liberia/liberia.dm"
+	#include "../../mods/valsalia/_valsalia.dme"
 
 	#define USING_MAP_DATUM /datum/map/away_sites_testing
 

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -1363,6 +1363,8 @@
 /obj/item/clothing/shoes/sandal/yinglet,
 /obj/item/clothing/shoes/sandal/yinglet,
 /obj/item/clothing/shoes/sandal/yinglet,
+/obj/item/clothing/suit/space/void/scav/matriarch,
+/obj/item/clothing/head/helmet/space/void/scav/matriarch,
 /turf/simulated/floor/tiled,
 /area/ship/trade/enclave)
 "rt" = (

--- a/mods/valsalia/items/voidsuits.dm
+++ b/mods/valsalia/items/voidsuits.dm
@@ -145,3 +145,26 @@
 	armour_colour = COLOR_GRAY40
 	faceplate_colour = COLOR_PALE_PURPLE_GRAY
 	stripe_colour = COLOR_PURPLE
+/obj/item/clothing/suit/space/void/scav/matriarch
+	name = "small matriarch voidsuit"
+	color = COLOR_BEASTY_BROWN
+	armour_colour = COLOR_GOLD
+	stripe_colour = COLOR_GREEN
+	
+/obj/item/clothing/head/helmet/space/void/scav/matriarch
+	name = "small matriarch voidsuit helmet"
+	color = COLOR_GREEN
+	armour_colour = COLOR_GOLD
+	faceplate_colour = COLOR_WHITE
+	stripe_colour = COLOR_GREEN
+
+/obj/item/clothing/suit/space/void/scav/merchant
+	name = "small merchant voidsuit"
+	color = COLOR_CHESTNUT
+	armour_colour = COLOR_CHESTNUT
+
+/obj/item/clothing/head/helmet/space/void/scav/merchant
+	name = "small merchant voidsuit helmet"
+	color = COLOR_CHESTNUT
+	armour_colour = COLOR_CHESTNUT
+	faceplate_colour = COLOR_RED

--- a/mods/valsalia/items/voidsuits.dm
+++ b/mods/valsalia/items/voidsuits.dm
@@ -145,3 +145,27 @@
 	armour_colour = COLOR_GRAY40
 	faceplate_colour = COLOR_PALE_PURPLE_GRAY
 	stripe_colour = COLOR_PURPLE
+
+/obj/item/clothing/suit/space/void/scav/matriarch
+	name = "small matriarch voidsuit"
+	color = COLOR_BEASTY_BROWN
+	armour_colour = COLOR_GOLD
+	stripe_colour = COLOR_GREEN
+	
+/obj/item/clothing/head/helmet/space/void/scav/matriarch
+	name = "small matriarch voidsuit helmet"
+	color = COLOR_GREEN
+	armour_colour = COLOR_GOLD
+	faceplate_colour = COLOR_WHITE
+	stripe_colour = COLOR_GREEN
+
+/obj/item/clothing/suit/space/void/scav/merchant
+	name = "small merchant voidsuit"
+	color = COLOR_CHESTNUT
+	armour_colour = COLOR_CHESTNUT
+
+/obj/item/clothing/head/helmet/space/void/scav/merchant
+	name = "small merchant voidsuit helmet"
+	color = COLOR_CHESTNUT
+	armour_colour = COLOR_CHESTNUT
+	faceplate_colour = COLOR_RED

--- a/mods/valsalia/items/voidsuits.dm
+++ b/mods/valsalia/items/voidsuits.dm
@@ -145,27 +145,3 @@
 	armour_colour = COLOR_GRAY40
 	faceplate_colour = COLOR_PALE_PURPLE_GRAY
 	stripe_colour = COLOR_PURPLE
-
-/obj/item/clothing/suit/space/void/scav/matriarch
-	name = "small matriarch voidsuit"
-	color = COLOR_BEASTY_BROWN
-	armour_colour = COLOR_GOLD
-	stripe_colour = COLOR_GREEN
-	
-/obj/item/clothing/head/helmet/space/void/scav/matriarch
-	name = "small matriarch voidsuit helmet"
-	color = COLOR_GREEN
-	armour_colour = COLOR_GOLD
-	faceplate_colour = COLOR_WHITE
-	stripe_colour = COLOR_GREEN
-
-/obj/item/clothing/suit/space/void/scav/merchant
-	name = "small merchant voidsuit"
-	color = COLOR_CHESTNUT
-	armour_colour = COLOR_CHESTNUT
-
-/obj/item/clothing/head/helmet/space/void/scav/merchant
-	name = "small merchant voidsuit helmet"
-	color = COLOR_CHESTNUT
-	armour_colour = COLOR_CHESTNUT
-	faceplate_colour = COLOR_RED


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Added in two new voidsuits, one for Liberia merchants, and another for the yinglet matriarch
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Yinglets aboard the liberia can actually do their job now, and the Yinglet Matriarch will finally have a voidsuits that displays her status
## Authorship
<!-- Describe original authors of changes to credit them. -->
Devchord
## Changelog
:cl:
add: Added a small merchant voidsuit and a small matriarch voidsuit
add: Added the merchant voidsuit to 5 lockers on the Liberia and the matriarch voidsuit to a single locker on tradeship
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->