### PR TITLE
Adds simple breath-holding functionality.

### DIFF
--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -4,14 +4,20 @@
 
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing()
-	if((life_tick % MOB_BREATH_DELAY) == 0 || failed_last_breath || is_asystole()) //First, resolve location and get a breath
+	if((life_tick - last_breath_tick >= MOB_BREATH_DELAY) || failed_last_breath || is_asystole())
 		breathe()
 
 /mob/living/carbon/proc/breathe(var/active_breathe = 1)
+	last_breath_tick = life_tick
 
 	if(!need_breathe()) return
 
-	var/datum/gas_mixture/breath = null
+	if(stat != CONSCIOUS && holding_breath)
+		holding_breath = (holding_breath >= 2 ? 3 : 0)
+
+	if(holding_breath == 3)
+		holding_breath = 0
+		handle_post_breath(breath)
 
 	//First, check if we can breathe at all
 	if(handle_drowning() || (is_asystole() && !GET_CHEMICAL_EFFECT(src, CE_STABLE) && active_breathe)) //crit aka circulatory shock
@@ -21,7 +27,7 @@
 		losebreath--
 		if (prob(10) && !is_asystole() && active_breathe) //Gasp per 10 ticks? Sounds about right.
 			INVOKE_ASYNC(src, .proc/emote, "gasp")
-	else
+	else if(holding_breath < 2 || !breath)
 		//Okay, we can breathe, now check if we can get air
 		var/volume_needed = get_breath_volume()
 		breath = get_breath_from_internal(volume_needed) //First, check for air from internals
@@ -34,6 +40,8 @@
 			breath = vacuum //still nothing? must be vacuum
 
 	handle_breath(breath)
+	if(holding_breath == 1)
+		holding_breath = 2
 	handle_post_breath(breath)
 
 /mob/living/carbon/proc/get_breath_from_internal(var/volume_needed=STD_BREATH_VOLUME) //hopefully this will allow overrides to specify a different default volume without breaking any cases where volume is passed in.
@@ -94,6 +102,8 @@
 	return
 
 /mob/living/carbon/proc/handle_post_breath(datum/gas_mixture/breath)
+	if(holding_breath)
+		return
 	if(breath)
 		//by default, exhale
 		var/datum/gas_mixture/internals_air = internal?.return_air()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -14,6 +14,7 @@
 /mob/living/carbon/Destroy()
 	QDEL_NULL(touching)
 	QDEL_NULL(bloodstr)
+	QDEL_NULL(breath)
 	reagents = null //We assume reagents is a reference to bloodstr here
 	delete_organs()
 	QDEL_NULL_LIST(hallucinations)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -10,6 +10,9 @@
 	var/datum/reagents/metabolism/touching
 	var/losebreath = 0 //if we failed to breathe last tick
 
+	var/datum/gas_mixture/breath = null
+	var/last_breath_tick = 0
+
 	var/coughedtime = null
 	var/ignore_rads = FALSE
 	/// Whether the mob is performing cpr or not.

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -6,10 +6,24 @@
 	set desc = "Smell the local area."
 	set category = "IC"
 	set src = usr
-	if(!incapacitated())
+	if(!incapacitated() && !holding_breath)
 		if(species.sniff_message_3p && species.sniff_message_1p)
 			visible_message(SPAN_NOTICE("\The [src] [species.sniff_message_3p]."), SPAN_NOTICE(species.sniff_message_1p))
 		LAZYCLEARLIST(smell_cooldown)
+
+/mob/living/carbon/human/verb/hold_breath()
+	set name = "Hold Breath"
+	set desc = "Hold your breath, or stop holding your breath."
+	set category = "IC"
+	set src = usr
+	if(stat == CONSCIOUS)
+		if(!holding_breath)
+			visible_message(SPAN_WARNING("\The [src] starts holding their breath!"), SPAN_WARNING("You start holding your breath!"))
+			holding_breath = 1
+		else
+			visible_message(SPAN_NOTICE("\The [src] starts breathing again."), SPAN_NOTICE("You stop holding your breath."))
+			holding_breath = (holding_breath >= 2 ? 3 : 0)
+		breathe()
 
 /mob/living/carbon/human/proc/tie_hair()
 	set name = "Tie Hair"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -792,7 +792,7 @@ default behaviour is:
 
 /mob/living/handle_drowning()
 	var/turf/T = get_turf(src)
-	if(!can_drown() || !loc.is_flooded(lying))
+	if(!can_drown() || !loc.is_flooded(lying) || holding_breath)
 		return FALSE
 	if(!lying && T.above && T.above.is_open() && !T.above.is_flooded() && can_overcome_gravity())
 		return FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -35,6 +35,7 @@
 	var/fire_stacks
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
+	var/holding_breath = 0 //Used for when the mob is trying to hold their breath. 1 means they need to get a breath, 2 means they're currently holding their breath, 3 means they're going to release their held breath.
 	var/possession_candidate // Can be possessed by ghosts if unplayed.
 
 	var/job = null//Living


### PR DESCRIPTION
## Description of changes
Adds simple breath-holding functionality. Not entirely balanced but better than nothing.

## Why and what will this PR improve
Without this, anyone without an oxygen tank and mask or immediate medical attention is physically unable to move through any amount of toxic gas without dying, regardless of whether or not they know it's there, easily trapping someone into being unable to interact with the round. While this will definitely need changes later on, it is best that this scenario not happen in the meantime.

## Authorship
Alceris

## Changelog
:cl:
add: Added ability to hold your breath.
/:cl: