### PR TITLE
Bearcat away map scavification

### DIFF
--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -458,6 +458,11 @@
 	dir = 4
 	},
 /obj/random/closet,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/item/stack/material/reinforced/mapped/plasteel/fifty,
+/obj/item/stack/material/reinforced/mapped/plasteel/fifty,
+/obj/item/stack/material/reinforced/mapped/plasteel/fifty,
+/obj/item/stack/material/reinforced/mapped/plasteel/fifty,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/cargo/lower)
 "be" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -286,6 +286,8 @@
 /obj/item/storage/backpack/dufflebag/syndie,
 /obj/item/storage/box/ammo/shotgunshells,
 /obj/item/handcuffs,
+/obj/item/clothing/suit/space/void/scav/security,
+/obj/item/clothing/head/helmet/space/void/scav/security,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "aL" = (
@@ -489,6 +491,7 @@
 /obj/item/chems/drinks/glass2/coffeecup/one,
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath/emergency,
+/obj/item/clothing/head/helmet/space/void/scav/security,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "bd" = (
@@ -1245,15 +1248,8 @@
 /turf/simulated/wall,
 /area/ship/scrap/crew/cryo)
 "cE" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
 /obj/structure/hygiene/shower{
 	dir = 4
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
 	},
 /obj/item/soap,
 /obj/structure/curtain/open/shower,
@@ -1266,17 +1262,6 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/hygiene/toilet,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/usedup,
@@ -1330,6 +1315,9 @@
 /obj/random/voidsuit,
 /obj/random/voidsuit,
 /obj/random/voidsuit,
+/obj/item/clothing/head/helmet/space/void/scav/security,
+/obj/item/clothing/suit/space/void/scav/security,
+/obj/item/tank/oxygen,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/crew/saloon)
 "cM" = (
@@ -1589,11 +1577,6 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted,
 /obj/structure/curtain/open/shower,
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/usedup,
@@ -1601,15 +1584,6 @@
 "dj" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -1619,15 +1593,6 @@
 /obj/structure/hygiene/toilet{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/derelict{
@@ -2518,6 +2483,7 @@
 /obj/item/ducttape,
 /obj/item/retractor,
 /obj/item/scalpel,
+/obj/item/tank/oxygen,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
 "eP" = (
@@ -5109,21 +5075,6 @@
 /obj/structure/hygiene/sink{
 	pixel_y = 18
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
@@ -5323,6 +5274,12 @@
 	},
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
+"KW" = (
+/obj/item/stack/material/rods,
+/obj/structure/lattice,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/space,
+/area/ship/scrap/maintenance/atmos)
 "Lp" = (
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -11245,7 +11202,7 @@ aa
 xU
 vs
 sy
-hM
+KW
 id
 io
 id


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
add yingsuits to the bearcat away map, plus a few minor other QoL tweaks (few more nitrogen canisters)

## Why and what will this PR improve
Lets Yinglets survive on the away map, and the extra canisters will let the ship actually be fully pressurized again if atmost is repaired.

## Authorship
Qumefox

## Changelog
:cl:
add: yingsuits to bearcat away map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->