### PR TITLE
fixed area names to remove holopad duplicates

### DIFF
--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -1,134 +1,134 @@
 /area/ship/scrap
-	name = "Generic Ship"
+	name = "\improper Generic Ship"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg')
 
 /area/ship/scrap/crew
-	name = "Crew Compartements"
+	name = "\improper Crew Compartements"
 	icon_state = "crew_quarters"
 
 /area/ship/scrap/crew/hallway/port
-	name = "Crew Hallway - Port"
+	name = "\improper Crew Hallway - Port"
 
 /area/ship/scrap/crew/hallway/starboard
-	name = "Crew Hallway - Starboard"
+	name = "\improper Crew Hallway - Starboard"
 
 /area/ship/scrap/crew/kitchen
-	name = "Galley"
+	name = "\improper Galley"
 	icon_state = "kitchen"
 
 /area/ship/scrap/crew/cryo
-	name = "Cryo Storage"
+	name = "\improper Cryo Storage"
 	icon_state = "cryo"
 
 /area/ship/scrap/crew/dorms1
-	name = "Crew Cabin #1"
+	name = "\improper Crew Cabin #1"
 	icon_state = "green"
 
 /area/ship/scrap/crew/dorms2
-	name = "Crew Cabin #2"
+	name = "\improper Crew Cabin #2"
 	icon_state = "purple"
 
 /area/ship/scrap/crew/dorms3
-	name = "Crew Cabin #3"
+	name = "\improper Crew Cabin #3"
 	icon_state = "yellow"
 
 /area/ship/scrap/crew/saloon
-	name = "Saloon"
+	name = "\improper Saloon"
 	icon_state = "conference"
 
 /area/ship/scrap/crew/toilets
-	name = "Bathrooms"
+	name = "\improper Bathrooms"
 	icon_state = "toilet"
 	turf_initializer = /decl/turf_initializer/maintenance
 
 /area/ship/scrap/crew/wash
-	name = "Washroom"
+	name = "\improper Washroom"
 	icon_state = "locker"
 
 /area/ship/scrap/crew/medbay
-	name = "Medical Bay"
+	name = "\improper Medical Bay"
 	icon_state = "medbay"
 
 /area/ship/scrap/cargo
-	name = "Cargo Hold"
+	name = "\improper Cargo Hold"
 	icon_state = "quartstorage"
 
 /area/ship/scrap/cargo/lower
-	name = "Lower Cargo Hold"
+	name = "\improper Lower Cargo Hold"
 
 /area/ship/scrap/dock
-	name = "Docking Bay"
+	name = "\improper Docking Bay"
 	icon_state = "entry_1"
 
 /area/ship/scrap/fire
-	name = "Firefighting Equipment Comparment"
+	name = "\improper Firefighting Equipment Comparment"
 	icon_state = "green"
 
 /area/ship/scrap/unused
-	name = "Compartment 2-B"
+	name = "\improper Compartment 2-B"
 	icon_state = "yellow"
 	turf_initializer = /decl/turf_initializer/maintenance
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg')
 
 /area/ship/scrap/hidden
-	name = "Unknown" //shielded compartment
+	name = "\improper Unknown" //shielded compartment
 	icon_state = "auxstorage"
 
 /area/ship/scrap/escape_port
-	name = "Port Escape Pods"
+	name = "\improper Port Escape Pods"
 	icon_state = "green"
 
 /area/ship/scrap/escape_star
-	name = "Starboard Escape Pods"
+	name = "\improper Starboard Escape Pods"
 	icon_state = "yellow"
 
 /area/ship/scrap/broken1
-	name = "Robotic Maintenance"
+	name = "\improper Robotic Maintenance"
 	icon_state = "green"
 
 /area/ship/scrap/broken2
-	name = "Compartment 1-B"
+	name = "\improper Compartment 1-B"
 	icon_state = "yellow"
 
 /area/ship/scrap/gambling
-	name = "Compartment 1-C"
+	name = "\improper Compartment 1-C"
 	icon_state = "cave"
 
 /area/ship/scrap/maintenance
-	name = "Maintenance Compartments"
+	name = "\improper Maintenance Compartments"
 	icon_state = "amaint"
 	req_access = list(access_bearcat)
 
 /area/ship/scrap/maintenance/hallway
-	name = "Maintenance Corridors"
+	name = "\improper Maintenance Corridors"
 
 /area/ship/scrap/maintenance/lower
-	name = "Lower Deck Maintenance Compartments"
+	name = "\improper Lower Deck Maintenance Compartments"
 	icon_state = "sub_maint_aft"
 
 /area/ship/scrap/maintenance/storage
-	name = "Tools Storage"
+	name = "\improper Tools Storage"
 	icon_state = "engineering_storage"
 
 /area/ship/scrap/maintenance/techstorage
-	name = "Parts Storage"
+	name = "\improper Parts Storage"
 	icon_state = "engineering_supply"
 
 /area/ship/scrap/maintenance/eva
-	name = "EVA Storage"
+	name = "\improper EVA Storage"
 	icon_state = "eva"
 
 /area/ship/scrap/maintenance/engineering
-	name = "Engineering Bay"
+	name = "\improper Engineering Bay"
 	icon_state = "engineering_supply"
 
 /area/ship/scrap/maintenance/atmos
-	name = "Atmospherics Comparment"
+	name = "\improper Atmospherics Comparment"
 	icon_state = "atmos"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambiatm1.ogg')
 
 /area/ship/scrap/maintenance/power
-	name = "Power Compartment"
+	name = "\improper Power Compartment"
 	icon_state = "engine_smes"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
 
@@ -137,35 +137,35 @@
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
 
 /area/ship/scrap/maintenance/engine/aft
-	name = "Main Engine Bay"
+	name = "\improper Main Engine Bay"
 
 /area/ship/scrap/maintenance/engine/port
-	name = "Port Thruster"
+	name = "\improper Port Thruster"
 
 /area/ship/scrap/maintenance/engine/starboard
-	name = "Starboard Thruster"
+	name = "\improper Starboard Thruster"
 
 /area/ship/scrap/command/hallway
-	name = "Command Deck"
+	name = "\improper Command Deck"
 	icon_state = "centcom"
 	req_access = list(access_bearcat)
 
 /area/ship/scrap/command/bridge
-	name = "Bridge"
+	name = "\improper Bearcat Bridge"
 	icon_state = "bridge"
 	req_access = list(access_bearcat)
 
 /area/ship/scrap/command/captain
-	name = "Captain's Quarters"
+	name = "\improper Captain's Quarters"
 	icon_state = "captain"
 	req_access = list(access_bearcat_captain)
 
 /area/ship/scrap/comms
-	name = "Communications Relay"
+	name = "\improper Communications Relay"
 	icon_state = "tcomsatcham"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/signal.ogg','sound/ambience/sonar.ogg')
 
 /area/ship/scrap/shuttle/lift
-  name = "Cargo Lift"
+  name = "\improper Cargo Lift"
   icon_state = "shuttle3"
   base_turf = /turf/simulated/open

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -2155,6 +2155,10 @@
 	},
 /turf/simulated/floor,
 /area/ship/trade/loading_bay)
+"VT" = (
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/wood/walnut,
+/area/ship/trade/enclave)
 "Xe" = (
 /turf/simulated/wall,
 /area/ship/trade/fore_port_underside_maint)
@@ -5336,7 +5340,7 @@ aa
 ab
 en
 ae
-en
+VT
 DV
 ax
 pU

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -197,7 +197,7 @@
 	icon_state = "centcom"
 
 /area/ship/trade/command/bridge
-	name = "\improper Bridge"
+	name = "\improper Tradeship Bridge"
 	icon_state = "bridge"
 	req_access = list(access_heads)
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Changes tradeship and bridge area names, and adds holopad in enclave

## Why and what will this PR improve
Bridge holopads on bearcat and tradeship couldn't talk to each other due to having the same area name, and thus, same holopad name.

A holopad for enclave level was also requested

## Authorship

## Changelog
:cl:
add: Added enclave holopad
tweak: area names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->