### PR TITLE
Name the new fax webhook properly..

### DIFF
--- a/code/modules/webhooks/webhook_fax_sent.dm
+++ b/code/modules/webhooks/webhook_fax_sent.dm
@@ -1,8 +1,8 @@
-/decl/webhook/fax_send
-	id = WEBHOOK_FAX_SEND
+/decl/webhook/fax_sent
+	id = WEBHOOK_FAX_SENT
 
 // Data expects a "text" field containing a message.
-/decl/webhook/fax_send/get_message(var/list/data)
+/decl/webhook/fax_sent/get_message(var/list/data)
 	. = ..()
 	.["embeds"] = list(list(
 		"title" = (data && data["title"]) || "undefined",


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Actually naming the webhook properly across all scripts

## Why and what will this PR improve
because sent != send...

## Authorship
Qumefox

## Changelog
:cl:
fix: webhook names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->