### PR TITLE
Ministation fixes 121622

### DIFF
--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -264,10 +264,10 @@
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
 "aL" = (
-/obj/structure/bed/chair/comfy/blue,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
+/obj/structure/bed/chair/office/comfy/blue,
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
 "aM" = (
@@ -281,13 +281,13 @@
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
 "aN" = (
-/obj/structure/bed/chair/comfy/blue,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/white{
 	dir = 5
 	},
+/obj/structure/bed/chair/office/comfy/blue,
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
 "aO" = (
@@ -3077,7 +3077,7 @@
 	id_tag = "science_shuttle_vent_out_internal"
 	},
 /obj/machinery/airlock_sensor{
-	id_tag = "science_shuttle__sensor";
+	id_tag = "science_shuttle_sensor";
 	pixel_y = 10;
 	pixel_x = -20
 	},
@@ -10979,7 +10979,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/airlock_sensor{
-	id_tag = "stern_engineering_sensor_exterior";
+	id_tag = "stern_engineering_sensor";
 	pixel_y = 10;
 	pixel_x = -20
 	},
@@ -10991,8 +10991,7 @@
 	tag_exterior_door = "stern_engineering_airlock_exterior";
 	tag_interior_door = "stern_engineering_airlock_interior";
 	dir = 4;
-	pixel_x = -20;
-	tag_exterior_sensor = "stern_engineering_sensor_exterior"
+	pixel_x = -20
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
@@ -17864,14 +17863,6 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/floor/plating,
 /area/ministation/hall/w)
-"Se" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "stern_engineering_sensor";
-	pixel_y = 10;
-	pixel_x = -20
-	},
-/turf/space,
-/area/space)
 "Sf" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/light{
@@ -53670,7 +53661,7 @@ HO
 Eo
 aa
 aa
-Se
+aa
 aa
 HY
 Uu

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -6144,6 +6144,12 @@
 "oN" = (
 /turf/simulated/wall,
 /area/ministation/janitor)
+"oO" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ministation/supermatter)
 "oP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/white,
@@ -8782,10 +8788,20 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hop)
 "vk" = (
-/obj/structure/closet/crate/bin/ministation,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/clothing/suit/storage/toggle/redcoat,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
 /turf/simulated/floor/tiled,
 /area/ministation/hop)
 "vl" = (
@@ -8794,10 +8810,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
 	},
 /obj/structure/sign/warning/radioactive{
 	pixel_y = -10;
@@ -9975,6 +9987,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet/officer,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "yh" = (
@@ -10438,6 +10452,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/ministation/supermatter)
 "zq" = (
@@ -10864,7 +10879,9 @@
 /obj/structure/closet/chefcloset,
 /obj/item/storage/box/ammo/beanbags,
 /obj/item/clothing/suit/storage/toggle/wintercoat/hydro,
-/obj/item/gun/projectile/shotgun/doublebarrel/sawn,
+/obj/item/gun/projectile/shotgun/doublebarrel/sawn{
+	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	},
 /turf/simulated/floor/wood,
 /area/ministation/cafe)
 "Av" = (
@@ -11833,6 +11850,8 @@
 /area/ministation/engine)
 "CK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/clothing/suit/storage/toggle/redcoat/yinglet/officer,
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "CL" = (
@@ -13873,6 +13892,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
 "Hy" = (
@@ -14357,6 +14379,15 @@
 /obj/structure/rack,
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
+"IM" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/engine)
 "IN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -14712,8 +14743,9 @@
 /turf/simulated/wall/r_wall,
 /area/ministation/ai_upload)
 "JO" = (
-/obj/structure/cable,
-/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/space)
 "JP" = (
@@ -16903,6 +16935,9 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
 "Pu" = (
@@ -17048,6 +17083,16 @@
 /obj/item/flashlight,
 /turf/simulated/floor/plating,
 /area/ministation/maint/sw)
+"PQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/engine)
 "PR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17233,6 +17278,9 @@
 /area/ministation/maint/nw)
 "Qv" = (
 /obj/machinery/power/supermatter,
+/obj/machinery/mass_driver{
+	id_tag = "eject"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ministation/supermatter)
 "Qw" = (
@@ -18089,6 +18137,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"SU" = (
+/obj/structure/closet/secure_closet/RD,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "SV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -18483,9 +18535,6 @@
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "TT" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
@@ -18675,6 +18724,12 @@
 	},
 /turf/space,
 /area/space)
+"Us" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ministation/supermatter)
 "Ut" = (
 /obj/structure/sign/goldenplaque/security{
 	pixel_y = 32
@@ -19084,6 +19139,7 @@
 /area/ministation/supermatter)
 "VD" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ministation/yinglet_enclave)
 "VF" = (
@@ -19116,6 +19172,7 @@
 /area/ministation/shuttle/outgoing)
 "VJ" = (
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ministation/maint/ne)
 "VK" = (
@@ -19754,6 +19811,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
+"XC" = (
+/obj/effect/wallframe_spawn/no_grille,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -19778,6 +19840,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ministation/yinglet_enclave)
 "XI" = (
@@ -20619,6 +20682,11 @@
 	name = "Vent Safety";
 	pixel_x = -36;
 	pixel_y = 9
+	},
+/obj/machinery/button/mass_driver{
+	pixel_y = -4;
+	pixel_x = -35;
+	id_tag = "eject"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
@@ -52568,7 +52636,7 @@ il
 Qa
 Qa
 Dt
-bk
+IM
 HE
 HL
 Eo
@@ -52819,7 +52887,7 @@ eK
 Pb
 NS
 Xf
-Ui
+oO
 Ui
 zR
 eK
@@ -53102,8 +53170,8 @@ Jt
 Jt
 GM
 GR
-GR
 JO
+aa
 aa
 aa
 aa
@@ -53359,7 +53427,7 @@ aa
 GI
 aa
 aa
-aa
+GP
 aa
 aa
 aa
@@ -53845,7 +53913,7 @@ SM
 Wj
 ZC
 dV
-eK
+Us
 BB
 qf
 yk
@@ -55127,7 +55195,7 @@ FU
 Gb
 RP
 Dz
-Gb
+PQ
 vl
 OJ
 PG
@@ -58661,7 +58729,7 @@ Ux
 Ux
 Ux
 Ux
-fx
+XC
 gQ
 Ic
 gQ
@@ -62530,7 +62598,7 @@ ZT
 db
 kz
 NM
-MI
+SU
 ae
 ae
 ae
@@ -62787,7 +62855,7 @@ db
 jw
 db
 NM
-db
+MI
 ae
 PW
 Yl


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixed engineering and shuttle airlocks
gave beanbag shells to bar shotgun
added headsets and recoats to hop office

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

broken airlocks break gameplay
headsets and uniforms help RP
barkeep should not have lethal ammunition

## Authorship
<!-- Describe original authors of changes to credit them. -->
Devchord

## Changelog
:cl:
add: spare headsets and redcoats to hop office
balance: changed shotgun shells in bar to beanbags
fix: fixed typos that broke the engineering and shuttle airlocks

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->