### PR TITLE
readdes the original ministation datum

### DIFF
--- a/mods/valsalia/map/overrides.dm
+++ b/mods/valsalia/map/overrides.dm
@@ -33,5 +33,8 @@
 	)
 	want_multiplier = 50 // pay good money for clam
 
+/datum/map/ministation
+	lobby_tracks = list(/decl/music_track/zazie)
+
 /datum/map/ministation2
 	lobby_tracks = list(/decl/music_track/zazie)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
readds the ministation define in valsalia/overrides.dm

## Why and what will this PR improve
Dev got a little overzealous about swapping ministation to ministation2, and in this file it should have been an addition instead of a replacement

## Authorship
qumefox

## Changelog
:cl:
fix: overrides.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->