### PR TITLE
Clippers,scanners,tiles

### DIFF
--- a/maps/ministation2/ministation-0.dmm
+++ b/maps/ministation2/ministation-0.dmm
@@ -1236,6 +1236,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
 "ga" = (
@@ -4912,9 +4915,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -10182,6 +10182,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
@@ -43035,7 +43038,7 @@ sC
 aV
 VZ
 Fi
-DC
+bk
 tg
 DC
 Zi
@@ -43549,7 +43552,7 @@ aV
 aV
 fZ
 Fi
-DC
+bk
 Gt
 DC
 Zi

--- a/maps/ministation2/ministation-1.dmm
+++ b/maps/ministation2/ministation-1.dmm
@@ -2861,6 +2861,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
 "sV" = (
@@ -4522,6 +4525,7 @@
 /obj/item/minihoe,
 /obj/item/minihoe,
 /obj/item/book/skill/service/botany,
+/obj/item/wirecutters/clippers,
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
 "zl" = (

--- a/maps/ministation2/ministation-2.dmm
+++ b/maps/ministation2/ministation-2.dmm
@@ -840,21 +840,14 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "di" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/ministation/hall/n3)
+/turf/simulated/floor/tiled,
+/area/ministation/bridge)
 "dn" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/paper_bin,
@@ -2677,6 +2670,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/research,
+/obj/item/wirecutters/clippers,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "mH" = (
@@ -3070,6 +3064,14 @@
 /obj/effect/overmap/visitable/ship/landable/science_shuttle,
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
+"rK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/s3)
 "rW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3126,6 +3128,12 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/ministation/yinglet_rep)
+"sY" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n3)
 "tc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3873,6 +3881,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/corner/purple{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
 "CN" = (
@@ -3960,6 +3971,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/court)
+"Da" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n3)
 "Dc" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -4933,6 +4953,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/court)
+"OQ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/bridge)
 "OU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5075,6 +5101,7 @@
 "PW" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist,
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/science,
+/obj/item/ano_scanner,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Qf" = (
@@ -5121,6 +5148,9 @@
 "Qs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
@@ -6166,6 +6196,9 @@
 "ZB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
@@ -37713,7 +37746,7 @@ iu
 iZ
 sD
 sD
-di
+Gu
 sD
 sD
 sD
@@ -38207,9 +38240,9 @@ Qs
 yd
 ZB
 bM
-aJ
+bZ
 yd
-sC
+sY
 sB
 sC
 sC
@@ -38719,11 +38752,11 @@ bA
 bM
 Qs
 yd
-aJ
+OQ
 bM
-bM
+di
 yd
-sB
+Da
 sC
 sC
 sC
@@ -39021,7 +39054,7 @@ fJ
 zy
 Co
 fJ
-fJ
+rK
 fJ
 SE
 fJ


### PR DESCRIPTION
Readded clippers to senobotany and hyrdoponic
Refixed the floor tiles
Added anomaly scanner to xenoarch

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->