### PR TITLE
changes bag of holding max item size

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -43,7 +43,7 @@
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	origin_tech = "{'wormholes':4}"
 	icon = 'icons/obj/items/storage/backpack/backpack_holding.dmi'
-	max_w_class = ITEM_SIZE_NORMAL
+	max_w_class = ITEM_SIZE_LARGE
 	max_storage_space = 56
 	material = /decl/material/solid/metal/gold
 	matter = list(
@@ -383,7 +383,7 @@
 		var/image/I = image(overlay.icon, "[overlay.icon_state]-[marking_state]")
 		I.color = marking_colour
 		I.appearance_flags |= RESET_COLOR
-		overlay.add_overlay(I)	
+		overlay.add_overlay(I)
 	. = ..()
 
 /obj/item/storage/backpack/ert/commander


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Updates bag of holding max item size.

## Why and what will this PR improve
Makes the bag of holding have the same max item size as regular backpacks, since well, it's a backpack.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Qumefox

## Changelog
:cl:
balance: Changes bag of holding max item size
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->