### PR TITLE
Ministation2fixes 5 17 23

### DIFF
--- a/maps/ministation2/jobs/civilian.dm
+++ b/maps/ministation2/jobs/civilian.dm
@@ -50,7 +50,7 @@
 		SKILL_COOKING	= SKILL_MAX,
 		SKILL_BOTANY	= SKILL_MAX
 	)
-	skill_points = 20
+	skill_points = 30
 
 /datum/job/ministation/cargo
 	title = "Cargo Technician"
@@ -94,7 +94,7 @@
 		SKILL_EVA		= SKILL_MAX,
 		SKILL_FINANCE	= SKILL_MAX
 	)
-	skill_points = 20
+	skill_points = 30
 	software_on_spawn = list(
 		/datum/computer_file/program/supply,
 		/datum/computer_file/program/deck_management,
@@ -134,7 +134,7 @@
 	min_skill = list(
 		SKILL_HAULING  = SKILL_BASIC
 	)
-	skill_points = 18
+	skill_points = 28
 
 /datum/job/ministation/librarian
 	title = "Librarian"

--- a/maps/ministation2/jobs/command.dm
+++ b/maps/ministation2/jobs/command.dm
@@ -12,7 +12,7 @@
 		SKILL_PILOT   = SKILL_MAX,
 		SKILL_WEAPONS = SKILL_MAX
 	)
-	skill_points = 30
+	skill_points = 40
 	head_position = 1
 	department_types = list(/decl/department/command)
 	total_positions = 1
@@ -169,5 +169,5 @@
 		SKILL_PILOT =   SKILL_MAX,
 		SKILL_FINANCE = SKILL_MAX
 	)
-	skill_points = 30
+	skill_points = 40
 	alt_titles = list("Head of Personnel")

--- a/maps/ministation2/jobs/engineering.dm
+++ b/maps/ministation2/jobs/engineering.dm
@@ -45,7 +45,7 @@
 		SKILL_ATMOS        = SKILL_MAX,
 		SKILL_ENGINES      = SKILL_MAX
 	)
-	skill_points = 20
+	skill_points = 30
 	alt_titles = list("Atmospheric Technician")
 	event_categories = list(ASSIGNMENT_ENGINEER)
 
@@ -130,6 +130,6 @@
 		SKILL_ATMOS        = SKILL_MAX,
 		SKILL_ENGINES      = SKILL_MAX
 	)
-	skill_points = 30
+	skill_points = 40
 	alt_titles = list("Head Engineer", "Chief Engineer", "Patriarch of Electricity")
 	event_categories = list(ASSIGNMENT_ENGINEER)

--- a/maps/ministation2/jobs/medical.dm
+++ b/maps/ministation2/jobs/medical.dm
@@ -6,7 +6,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	alt_titles = list("Chemist","Nurse")
-	skill_points = 24
+	skill_points = 34
 	min_skill = list(
 		SKILL_LITERACY  = SKILL_ADEPT,
 		SKILL_MEDICAL   = SKILL_EXPERT,
@@ -51,7 +51,7 @@
 	alt_titles = list("Surgeon","Head Doctor")
 	total_positions = 1
 	spawn_positions = 1
-	skill_points = 28
+	skill_points = 38
 	guestbanned = 1
 	must_fill = 1
 	not_random_selectable = 1

--- a/maps/ministation2/jobs/science.dm
+++ b/maps/ministation2/jobs/science.dm
@@ -18,7 +18,7 @@
 		SKILL_DEVICES  = SKILL_MAX,
 		SKILL_SCIENCE  = SKILL_MAX
 	)
-	skill_points = 24
+	skill_points = 34
 	access = list(
 		access_robotics,
 		access_tox,
@@ -60,7 +60,7 @@
 		SKILL_DEVICES  = SKILL_MAX,
 		SKILL_SCIENCE  = SKILL_MAX
 	)
-	skill_points = 30
+	skill_points = 40
 	head_position = 1
 	department_types = list(
 		/decl/department/science,

--- a/maps/ministation2/jobs/security.dm
+++ b/maps/ministation2/jobs/security.dm
@@ -32,7 +32,7 @@
 		SKILL_COMBAT	= SKILL_MAX,
 		SKILL_WEAPONS	= SKILL_MAX
 	)
-	skill_points = 20
+	skill_points = 30
 	event_categories = list(ASSIGNMENT_SECURITY)
 
 /datum/job/ministation/detective
@@ -72,7 +72,7 @@
 		SKILL_WEAPONS	= SKILL_MAX,
 		SKILL_FORENSICS	= SKILL_MAX
 	)
-	skill_points = 24
+	skill_points = 34
 
 /datum/job/ministation/security/head
 	title = "Patriarch of Security"
@@ -137,5 +137,5 @@
 		SKILL_COMBAT	= SKILL_MAX,
 		SKILL_WEAPONS	= SKILL_MAX
 	)
-	skill_points = 30
+	skill_points = 40
 	alt_titles = list("Head of Security","Patriarch of Scouting")

--- a/maps/ministation2/jobs/tradehouse.dm
+++ b/maps/ministation2/jobs/tradehouse.dm
@@ -21,7 +21,7 @@
 		SKILL_MEDICAL  = SKILL_MAX,
 		SKILL_ANATOMY  = SKILL_EXPERT
 	)
-	skill_points = 25
+	skill_points = 35
 	department_types = list(/decl/department/tradehouse)
 	selection_color = "#a89004"
 	access = list(

--- a/maps/ministation2/ministation-0.dmm
+++ b/maps/ministation2/ministation-0.dmm
@@ -541,6 +541,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
+"dg" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "di" = (
 /turf/simulated/wall,
 /area/ministation/hall/n)
@@ -1131,6 +1138,8 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
+/obj/item/chems/drinks/juicebox/random,
+/obj/item/chems/drinks/juicebox/sensible_random,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "fz" = (
@@ -1452,6 +1461,9 @@
 	id_tag = "cargoshut";
 	name = "cargo shutters"
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "gu" = (
@@ -1465,13 +1477,13 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "gw" = (
-/obj/structure/closet/crate/bin/ministation,
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/obj/item/chems/drinks/juicebox/random,
-/obj/item/chems/drinks/juicebox/random,
-/obj/item/chems/drinks/juicebox/sensible_random,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "gx" = (
@@ -3492,6 +3504,12 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
+"tJ" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "tU" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3544,7 +3562,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/structure/closet/crate/bin/ministation,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/ministation/engine)
@@ -3982,6 +3999,12 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
+"xp" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/space,
+/area/space)
 "xq" = (
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
@@ -4296,6 +4319,13 @@
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
+"zV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/ministation/maint/westatmos)
 "zW" = (
 /turf/simulated/wall,
 /area/ministation/dorms)
@@ -5256,6 +5286,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor,
 /area/ministation/maint/eastatmos)
 "DK" = (
@@ -7243,6 +7274,16 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
+"IE" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/item/chems/drinks/juicebox/random,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
@@ -10280,7 +10321,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction/mirrored{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -38181,7 +38222,7 @@ aa
 aa
 aa
 aa
-aa
+xp
 aa
 ad
 ad
@@ -40235,7 +40276,7 @@ aa
 aa
 aa
 cn
-cn
+tJ
 au
 cR
 cx
@@ -40550,7 +40591,7 @@ XA
 re
 Qz
 oi
-Am
+zV
 DD
 av
 av
@@ -41059,7 +41100,7 @@ aa
 aa
 aa
 aa
-aa
+dg
 uK
 AM
 AW
@@ -42545,7 +42586,7 @@ aa
 aa
 aa
 aa
-aa
+xp
 aa
 aa
 wm
@@ -43069,10 +43110,10 @@ wm
 me
 wm
 eM
-fy
+IE
 fy
 gw
-gQ
+uY
 TC
 di
 iu
@@ -44882,7 +44923,7 @@ aa
 aa
 aa
 DU
-aa
+dg
 aa
 aa
 aa
@@ -48017,7 +48058,7 @@ ad
 aa
 aa
 ad
-aa
+dg
 aa
 aa
 aa
@@ -50572,7 +50613,7 @@ aa
 aa
 aa
 aa
-aa
+dg
 aa
 aa
 aa

--- a/maps/ministation2/ministation-0.dmm
+++ b/maps/ministation2/ministation-0.dmm
@@ -255,6 +255,16 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
+"bU" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/item/chems/drinks/juicebox/random,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "bV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -587,17 +597,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1central)
-"dA" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
-	},
-/obj/item/chems/drinks/juicebox/random,
-/obj/item/chems/drinks/juicebox/sensible_random,
-/turf/simulated/floor/tiled,
-/area/ministation/hall/n)
 "dB" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -1143,6 +1142,7 @@
 	dir = 9
 	},
 /obj/item/chems/drinks/juicebox/random,
+/obj/item/chems/drinks/juicebox/sensible_random,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "fz" = (
@@ -1251,6 +1251,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/cargo,
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/cargo,
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/quartermaster,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "fR" = (
@@ -1262,10 +1263,10 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "fS" = (
-/obj/machinery/computer/modular/preset/supply_public,
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
+/obj/machinery/computer/modular/preset/merchant/ministation,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "fU" = (
@@ -2029,13 +2030,6 @@
 "jI" = (
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1nw)
-"jJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/ministation/maint/westatmos)
 "jL" = (
 /obj/item/pen,
 /turf/simulated/floor/tiled,
@@ -2777,6 +2771,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/westatmos)
+"nB" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/space,
+/area/space)
 "nE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2840,6 +2840,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/westatmos)
+"og" = (
+/obj/machinery/merchant_pad,
+/turf/simulated/floor/tiled,
+/area/ministation/cargo)
 "oi" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200;
@@ -3902,12 +3906,6 @@
 "wm" = (
 /turf/simulated/wall,
 /area/ministation/maint/l1nw)
-"wo" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/space,
-/area/space)
 "wp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/yew,
@@ -4032,13 +4030,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
-"xx" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/turf/space,
-/area/space)
 "xE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4992,6 +4983,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ministation/atmospherics)
+"CK" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "CL" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
@@ -7292,8 +7290,6 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/quartermaster,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "II" = (
@@ -10201,12 +10197,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
-"Tk" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "Tl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10525,6 +10515,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"UD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/ministation/maint/westatmos)
 "UG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -10859,6 +10856,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"Wp" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "Wr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -38224,7 +38227,7 @@ aa
 aa
 aa
 aa
-wo
+nB
 aa
 ad
 ad
@@ -40278,7 +40281,7 @@ aa
 aa
 aa
 cn
-Tk
+Wp
 au
 cR
 cx
@@ -40593,7 +40596,7 @@ XA
 re
 Qz
 oi
-jJ
+UD
 DD
 av
 av
@@ -41102,7 +41105,7 @@ aa
 aa
 aa
 aa
-xx
+CK
 uK
 AM
 AW
@@ -41828,7 +41831,7 @@ wm
 IK
 au
 ft
-dI
+og
 ky
 Ti
 ht
@@ -42588,7 +42591,7 @@ aa
 aa
 aa
 aa
-wo
+nB
 aa
 aa
 wm
@@ -43112,8 +43115,8 @@ wm
 me
 wm
 eM
+bU
 fy
-dA
 gw
 uY
 TC
@@ -44925,7 +44928,7 @@ aa
 aa
 aa
 DU
-xx
+CK
 aa
 aa
 aa
@@ -48060,7 +48063,7 @@ ad
 aa
 aa
 ad
-xx
+CK
 aa
 aa
 aa
@@ -50615,7 +50618,7 @@ aa
 aa
 aa
 aa
-xx
+CK
 aa
 aa
 aa

--- a/maps/ministation2/ministation-0.dmm
+++ b/maps/ministation2/ministation-0.dmm
@@ -541,13 +541,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
-"dg" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/turf/space,
-/area/space)
 "di" = (
 /turf/simulated/wall,
 /area/ministation/hall/n)
@@ -594,6 +587,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1central)
+"dA" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/item/chems/drinks/juicebox/random,
+/obj/item/chems/drinks/juicebox/sensible_random,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "dB" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -1139,7 +1143,6 @@
 	dir = 9
 	},
 /obj/item/chems/drinks/juicebox/random,
-/obj/item/chems/drinks/juicebox/sensible_random,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "fz" = (
@@ -2026,6 +2029,13 @@
 "jI" = (
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1nw)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/ministation/maint/westatmos)
 "jL" = (
 /obj/item/pen,
 /turf/simulated/floor/tiled,
@@ -3504,12 +3514,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
-"tJ" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "tU" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3898,6 +3902,12 @@
 "wm" = (
 /turf/simulated/wall,
 /area/ministation/maint/l1nw)
+"wo" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/space,
+/area/space)
 "wp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/yew,
@@ -3999,12 +4009,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
-"xp" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/space,
-/area/space)
 "xq" = (
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
@@ -4028,6 +4032,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
+"xx" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "xE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4319,13 +4330,6 @@
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /turf/simulated/floor/plating,
 /area/ministation/supermatter)
-"zV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/ministation/maint/westatmos)
 "zW" = (
 /turf/simulated/wall,
 /area/ministation/dorms)
@@ -7274,16 +7278,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
-"IE" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
-	},
-/obj/item/chems/drinks/juicebox/random,
-/turf/simulated/floor/tiled,
-/area/ministation/hall/n)
 "IF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
@@ -7298,6 +7292,8 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/quartermaster,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "II" = (
@@ -10205,6 +10201,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"Tk" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "Tl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38222,7 +38224,7 @@ aa
 aa
 aa
 aa
-xp
+wo
 aa
 ad
 ad
@@ -40276,7 +40278,7 @@ aa
 aa
 aa
 cn
-tJ
+Tk
 au
 cR
 cx
@@ -40591,7 +40593,7 @@ XA
 re
 Qz
 oi
-zV
+jJ
 DD
 av
 av
@@ -41100,7 +41102,7 @@ aa
 aa
 aa
 aa
-dg
+xx
 uK
 AM
 AW
@@ -42586,7 +42588,7 @@ aa
 aa
 aa
 aa
-xp
+wo
 aa
 aa
 wm
@@ -43110,8 +43112,8 @@ wm
 me
 wm
 eM
-IE
 fy
+dA
 gw
 uY
 TC
@@ -44923,7 +44925,7 @@ aa
 aa
 aa
 DU
-dg
+xx
 aa
 aa
 aa
@@ -48058,7 +48060,7 @@ ad
 aa
 aa
 ad
-dg
+xx
 aa
 aa
 aa
@@ -50613,7 +50615,7 @@ aa
 aa
 aa
 aa
-dg
+xx
 aa
 aa
 aa

--- a/maps/ministation2/ministation-0.dmm
+++ b/maps/ministation2/ministation-0.dmm
@@ -255,16 +255,6 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
-"bU" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 9
-	},
-/obj/item/chems/drinks/juicebox/random,
-/turf/simulated/floor/tiled,
-/area/ministation/hall/n)
 "bV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -1251,7 +1241,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/cargo,
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/cargo,
-/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/quartermaster,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "fR" = (
@@ -2771,12 +2760,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/westatmos)
-"nB" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/space,
-/area/space)
 "nE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2840,10 +2823,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/westatmos)
-"og" = (
-/obj/machinery/merchant_pad,
-/turf/simulated/floor/tiled,
-/area/ministation/cargo)
 "oi" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200;
@@ -3518,6 +3497,13 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
+"tO" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin/ministation,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/s1)
 "tU" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3565,6 +3551,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
+"uj" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/item/chems/drinks/juicebox/random,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "ul" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3965,6 +3961,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/janitor)
+"wZ" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "xg" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -4030,6 +4032,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
+"xw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/ministation/maint/westatmos)
 "xE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4983,13 +4992,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ministation/atmospherics)
-"CK" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/turf/space,
-/area/space)
 "CL" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
@@ -7290,6 +7292,10 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
+/obj/structure/closet/secure_closet/quartermaster{
+	req_access = list("ACCESS_MINING")
+	},
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/quartermaster,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "II" = (
@@ -9350,6 +9356,13 @@
 "Pp" = (
 /turf/space,
 /area/ministation/supply_dock)
+"Pr" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "Ps" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -9518,6 +9531,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
+"Qq" = (
+/obj/structure/closet/crate/bin/ministation,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "Qt" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -10515,13 +10532,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
-"UD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/ministation/maint/westatmos)
 "UG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -10648,6 +10658,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/smcontrol)
+"Vq" = (
+/obj/machinery/merchant_pad,
+/turf/simulated/floor/tiled,
+/area/ministation/cargo)
 "Vr" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -10856,12 +10870,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/engine)
-"Wp" = (
-/obj/item/mollusc/barnacle{
-	pixel_x = 20
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "Wr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10986,6 +10994,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/eastatmos)
+"WY" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = 20
+	},
+/turf/space,
+/area/space)
 "Xb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -11565,6 +11579,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/westatmos)
+"ZK" = (
+/obj/structure/closet/crate/bin/ministation,
+/turf/simulated/floor/plating,
+/area/ministation/trash)
 "ZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -38227,7 +38245,7 @@ aa
 aa
 aa
 aa
-nB
+WY
 aa
 ad
 ad
@@ -40281,7 +40299,7 @@ aa
 aa
 aa
 cn
-Wp
+wZ
 au
 cR
 cx
@@ -40596,7 +40614,7 @@ XA
 re
 Qz
 oi
-UD
+xw
 DD
 av
 av
@@ -41105,7 +41123,7 @@ aa
 aa
 aa
 aa
-CK
+Pr
 uK
 AM
 AW
@@ -41584,7 +41602,7 @@ jh
 Yx
 pZ
 hf
-hf
+ZK
 uM
 do
 jh
@@ -41831,7 +41849,7 @@ wm
 IK
 au
 ft
-og
+Vq
 ky
 Ti
 ht
@@ -42108,7 +42126,7 @@ dU
 di
 di
 gQ
-gQ
+Qq
 kZ
 sy
 MN
@@ -42591,7 +42609,7 @@ aa
 aa
 aa
 aa
-nB
+WY
 aa
 aa
 wm
@@ -43115,7 +43133,7 @@ wm
 me
 wm
 eM
-bU
+uj
 fy
 gw
 uY
@@ -43157,7 +43175,7 @@ Pa
 ms
 Aj
 Bn
-Bn
+tO
 Bn
 Ec
 ms
@@ -44928,7 +44946,7 @@ aa
 aa
 aa
 DU
-CK
+Pr
 aa
 aa
 aa
@@ -48063,7 +48081,7 @@ ad
 aa
 aa
 ad
-CK
+Pr
 aa
 aa
 aa
@@ -50618,7 +50636,7 @@ aa
 aa
 aa
 aa
-CK
+Pr
 aa
 aa
 aa

--- a/maps/ministation2/ministation-1.dmm
+++ b/maps/ministation2/ministation-1.dmm
@@ -404,8 +404,10 @@
 /turf/simulated/floor/plating,
 /area/ministation/detective)
 "dc" = (
-/obj/structure/closet/crate/bin/ministation,
-/obj/random/trash,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/carpet,
 /area/ministation/hall/w2)
 "dd" = (
@@ -517,17 +519,16 @@
 /turf/simulated/floor/tiled,
 /area/ministation/security)
 "dZ" = (
-/obj/machinery/door/window/brigdoor/westleft,
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters/open{
-	id_tag = "barshut";
-	name = "bar shutters"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/civilian{
+	autoset_access = 0;
+	name = "Kitchen airlock";
+	req_access = list("ACCESS_KITCHEN")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cafe)
@@ -2970,6 +2971,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/hallway,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
 "sv" = (
@@ -2977,6 +2981,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -3080,8 +3087,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
@@ -3989,7 +3996,10 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hop)
 "wc" = (
-/obj/structure/closet/crate/bin/ministation,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
 "wk" = (
@@ -5076,9 +5086,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "conpipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
@@ -5553,6 +5562,13 @@
 /obj/item/flashlight/maglight,
 /turf/simulated/floor/tiled,
 /area/ministation/security)
+"DI" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "DJ" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
@@ -7108,6 +7124,16 @@
 	},
 /turf/simulated/open,
 /area/ministation/maint/hydromaint)
+"RQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/w2)
 "RU" = (
 /obj/machinery/camera/network/medbay{
 	dir = 4
@@ -7372,6 +7398,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
+"Uw" = (
+/obj/structure/lattice,
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "Uz" = (
 /obj/machinery/door/airlock/external/glass{
 	autoset_access = 0;
@@ -35017,7 +35051,7 @@ kZ
 Wa
 qF
 dc
-rn
+RQ
 aV
 bI
 XK
@@ -35531,7 +35565,7 @@ dd
 dd
 dd
 kZ
-rn
+Kr
 GZ
 aV
 aV
@@ -36039,7 +36073,7 @@ aa
 aa
 aa
 aa
-aa
+DI
 aa
 aa
 mq
@@ -42220,7 +42254,7 @@ ty
 Om
 mH
 aa
-aa
+DI
 aa
 aa
 aa
@@ -45285,7 +45319,7 @@ aa
 aa
 aa
 aa
-aa
+DI
 Rx
 jW
 cY
@@ -48909,7 +48943,7 @@ mC
 oz
 aa
 aa
-ad
+Uw
 ad
 aa
 aa
@@ -53520,7 +53554,7 @@ aa
 aa
 aa
 aa
-aa
+DI
 oz
 Cx
 Cx

--- a/maps/ministation2/ministation-1.dmm
+++ b/maps/ministation2/ministation-1.dmm
@@ -2198,6 +2198,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/ministation/hall/w2)
+"pu" = (
+/obj/structure/closet/crate/bin/ministation,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/w2)
 "pA" = (
 /obj/structure/table,
 /obj/item/chems/drinks/glass2/mug,
@@ -39929,7 +39933,7 @@ HO
 HO
 HO
 rt
-aV
+pu
 aV
 aV
 oX

--- a/maps/ministation2/ministation-2.dmm
+++ b/maps/ministation2/ministation-2.dmm
@@ -2737,6 +2737,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
+"nz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/mirrored{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "nA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -41436,7 +41445,7 @@ Sm
 te
 LC
 iJ
-hG
+nz
 hG
 hG
 hG

--- a/maps/ministation2/ministation-2.dmm
+++ b/maps/ministation2/ministation-2.dmm
@@ -1253,7 +1253,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "fh" = (
-/obj/structure/closet/crate/bin/ministation,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "fi" = (
@@ -1365,6 +1368,9 @@
 /area/ministation/science)
 "gi" = (
 /obj/machinery/smartfridge/secure/extract,
+/obj/structure/disposalpipe/segment/bent{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "gn" = (
@@ -1400,14 +1406,12 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "gF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/ministation/science)
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "gG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1609,6 +1613,9 @@
 /obj/structure/table,
 /obj/item/storage/box/syringes,
 /obj/item/chems/glass/beaker/large,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "hG" = (
@@ -1873,6 +1880,9 @@
 	name = "Xenobiology"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "iQ" = (
@@ -2225,7 +2235,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin/ministation,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kx" = (
@@ -2918,6 +2927,13 @@
 /obj/machinery/computer/modular/preset/engineering,
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
+"pa" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/space,
+/area/space)
 "pb" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
@@ -3196,6 +3212,9 @@
 /obj/item/extinguisher{
 	pixel_x = 4;
 	pixel_y = 3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -4031,6 +4050,9 @@
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes,
 /obj/item/stack/material/puck/mapped/uranium/ten,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Cy" = (
@@ -5313,6 +5335,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "OM" = (
@@ -5700,6 +5725,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -6307,6 +6335,9 @@
 	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -36474,7 +36505,7 @@ aa
 aa
 aa
 aa
-aa
+pa
 ah
 aR
 br
@@ -36759,7 +36790,7 @@ aa
 aa
 aa
 cw
-cw
+gF
 Cd
 Oo
 Lq
@@ -40112,7 +40143,7 @@ cw
 cw
 cw
 cw
-cw
+gF
 ae
 dw
 dt
@@ -42433,7 +42464,7 @@ db
 fb
 db
 db
-gF
+RV
 GJ
 ae
 hK
@@ -43717,7 +43748,7 @@ dA
 eh
 ae
 fh
-db
+LC
 gi
 ae
 hM
@@ -45016,7 +45047,7 @@ VX
 WA
 ae
 cw
-aa
+pa
 aa
 aa
 aa


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Robot rechargers are now located nearby drone fabricators. Disposal network has been extended. A door has been placed to allow access between the bar and hydro. Some barnacles can now be located on the station hull. Added 10 skill points to each occupation to accommodate low pop rounds. Fixed the missing cargo teleporter

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
General fixes that will help improve game quality
## Authorship
<!-- Describe original authors of changes to credit them. -->
Devchord
## Changelog
:cl:
add: Added robot rechargers next to drone fabs
add: Added more chutes to the disposal network
add: Added barnacles to the exterior hull
add: Added door between bar and hydro
balance: added 10 skillpoints to each role
fix: fixed missing teleporter pad for cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->