### PR TITLE
Suit cycler override/extend bodytypes list fix

### DIFF
--- a/mods/valsalia/items/suit_cycler.dm
+++ b/mods/valsalia/items/suit_cycler.dm
@@ -1,5 +1,6 @@
-/obj/machinery/suit_cycler
-	available_bodytypes = list(BODYTYPE_HUMANOID, BODYTYPE_YINGLET)
+/obj/machinery/suit_cycler/Initialize()
+	. = ..()
+	available_bodytypes += BODYTYPE_YINGLET
 
 /obj/machinery/suit_cycler/tradeship
 	boots = /obj/item/clothing/shoes/magboots


### PR DESCRIPTION
## Description of changes
Replacing overriding suit cycler bodytype options with appending yinglet bodytype to the original list.

## Why and what will this PR improve
Before: allegedly sometimes suit cycler allows only human and yinglet bodytypes to refit to.
After: suit cycler allows human, yinglet and avain bodytypes.

## Authorship
Myself.

## Changelog
:cl:
refactor: fixed the suit cycler refitting bodytypes list
/:cl:
