### PR TITLE
Prevent baxxid/indrel getting prosthetics until someone sprites a proper set.

### DIFF
--- a/mods/valsalia/species/baxxid.dm
+++ b/mods/valsalia/species/baxxid.dm
@@ -58,6 +58,7 @@
 		/decl/natural_attack/bite/strong
 	)
 
+	base_prosthetics_model = null
 	base_color = "#c7b8aa"
 	base_eye_color = "#003366"
 	base_markings = list(

--- a/mods/valsalia/species/indrel.dm
+++ b/mods/valsalia/species/indrel.dm
@@ -79,6 +79,8 @@ var/global/list/pheromone_markers = list()
 	appearance_flags = HAS_EYE_COLOR
 	species_flags = SPECIES_FLAG_NO_MINOR_CUT
 
+	base_prosthetics_model = null
+
 	unarmed_attacks = list(
 		/decl/natural_attack/claws/strong,
 		/decl/natural_attack/bite/strong


### PR DESCRIPTION
They inherit the human base prosthetics, which are visually broken. If someone sprites prosthetic icons for them it's easy to plug in new ones.