### PR TITLE
Removes vox includes from mollusc and tradeship

### DIFF
--- a/maps/ministation2/ministation2.dm
+++ b/maps/ministation2/ministation2.dm
@@ -17,7 +17,7 @@ And then imported back to ScavStation!
 	#include "../../mods/content/matchmaking/_matchmaking.dme"
 	#include "../../mods/species/ascent/_ascent.dme"
 	#include "../../mods/species/neoavians/_neoavians.dme"
-	#include "../../mods/species/vox/_vox.dme"
+	//#include "../../mods/species/vox/_vox.dme"
 	#include "../../mods/species/serpentid/_serpentid.dme"
 	#include "../../mods/species/bayliens/_bayliens.dme"
 	#include "../../mods/content/mundane.dm"

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -22,7 +22,7 @@
 	#include "../../mods/valsalia/_valsalia.dme"
 	#include "../../mods/species/neoavians/_neoavians.dme"
 	#include "../../mods/species/bayliens/_bayliens.dme"
-	#include "../../mods/species/vox/_vox.dme"
+	//#include "../../mods/species/vox/_vox.dme"
 
 	#include "../away/bearcat/bearcat.dm"
 	#include "../away/casino/casino.dm"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Removes the includes for Vox from both our normal maps.

## Why and what will this PR improve
Vox shouldn't really be playable.

## Authorship
Qumefox

## Changelog
:cl:
del: Vox includes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->