### PR TITLE
Fixes some issues with the crashed pod

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -63,5 +63,5 @@ var/global/list/crashed_pod_areas = list()
 	. = ..()
 
 /obj/structure/sign/plaque/ai_dev/pod
-	desc = "A plaque with information regarding this particular lifepod. It reads: 'Armalev Industries Skyfin-E, Exoplanetary Suvival Pod' there's a registry number, and an assigned mothership, but they've both been scratched to illegiblity."
+	desc = "A plaque with information regarding this particular lifepod. It reads: 'Yoyodyne Propulsion Systems Exoplanetary Suvival Pod MK 7' there's a registry number, and an assigned mothership, but they've both been scratched to illegiblity."
 	name = "\improper Lifepod Plaque"

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -418,6 +418,7 @@
 	},
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/plaque/ai_dev/pod,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "aL" = (
@@ -1281,10 +1282,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"uw" = (
-/obj/structure/sign/plaque/ai_dev/pod,
-/turf/simulated/wall,
-/area/map_template/crashed_pod)
 "yo" = (
 /obj/item/bedsheet/brown,
 /obj/structure/curtain/open/privacy,
@@ -1307,18 +1304,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
-"Li" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	pixel_y = -18;
-	dir = 1;
-	locked = 0
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
 "Ta" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1332,6 +1317,9 @@
 "Ut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "Ys" = (
@@ -1417,7 +1405,7 @@ ac
 ae
 ay
 as
-uw
+ay
 aK
 aO
 bQ
@@ -1455,7 +1443,7 @@ ak
 at
 ay
 aS
-Li
+aB
 bL
 ay
 bk


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Just as it says on the tin.  Mostly fixes misaligned things like air alarms and the plaque, and adds another light to 'engineering'

## Why and what will this PR improve
because these were floating in the walkways

## Authorship
Qumefox

## Changelog
:cl:
tweak: tweaked a few things about the survival pod
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->