### PR TITLE
Removes overmap start defines for tradeship and mollusc

### DIFF
--- a/maps/ministation2/ministation_overmap.dm
+++ b/maps/ministation2/ministation_overmap.dm
@@ -1,8 +1,8 @@
 /obj/effect/overmap/visitable/ship/ministation
 	name = "Tradepost Mollusc"
 	color = "#00ffff"
-	start_x = 4
-	start_y = 4
+//	start_x = 4
+//	start_y = 4
 	vessel_mass = 5000
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 2 SECONDS

--- a/maps/tradeship/tradeship_overmap.dm
+++ b/maps/tradeship/tradeship_overmap.dm
@@ -1,8 +1,8 @@
 /obj/effect/overmap/visitable/ship/tradeship
 	name = "Tradeship Ivenmoth"
 	color = "#00ffff"
-	start_x = 4
-	start_y = 4
+//	start_x = 4
+//	start_y = 4
 	vessel_mass = 5000
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 2 SECONDS


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
removes start coord defines for tradeship and mollusc

## Why and what will this PR improve
stops tradeship and mollusc from always starting at 4:4

## Authorship
Qumefox

## Changelog
:cl:
tweak: map start coords
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->