### PR TITLE
Fixed traitor issues, late addded traitors should get uplink and code words

### DIFF
--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -85,12 +85,19 @@
 			player.StoreMemory("<b>Potential Collaborator</b>: [M.real_name]", /decl/memory_options/system)
 			to_chat(M, "<span class='warning'>The subversive potential of your faction has been noticed, and you may be contacted for assistance soon...</span>")
 
-		to_chat(player.current, "<u><b>Your employers provided you with the following information on how to identify possible allies:</b></u>")
-		to_chat(player.current, "<b>Code Phrase</b>: <span class='danger'>[syndicate_code_phrase]</span>")
-		to_chat(player.current, "<b>Code Response</b>: <span class='danger'>[syndicate_code_response]</span>")
-		player.StoreMemory("<b>Code Phrase</b>: [syndicate_code_phrase]", /decl/memory_options/system)
-		player.StoreMemory("<b>Code Response</b>: [syndicate_code_response]", /decl/memory_options/system)
-		to_chat(player.current, "Use the code words, preferably in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
+			spawn_uplink(M)
+
+			to_chat(player.current, "<u><b>Your employers provided you with the following information on how to identify possible allies:</b></u>")
+			to_chat(player.current, "<b>Code Phrase</b>: <span class='danger'>[syndicate_code_phrase]</span>")
+			to_chat(player.current, "<b>Code Response</b>: <span class='danger'>[syndicate_code_response]</span>")
+			to_chat(M, "<b>Code Phrase</b>: <span class='danger'>[syndicate_code_phrase]</span>")
+			to_chat(M, "<b>Code Response</b>: <span class='danger'>[syndicate_code_response]</span>")
+			player.StoreMemory("<b>Code Phrase</b>: [syndicate_code_phrase]", /decl/memory_options/system)
+			player.StoreMemory("<b>Code Response</b>: [syndicate_code_response]", /decl/memory_options/system)
+			M.StoreMemory("<b>Code Phrase</b>: [syndicate_code_phrase]", /decl/memory_options/system)
+			M.StoreMemory("<b>Code Response</b>: [syndicate_code_response]", /decl/memory_options/system)
+			to_chat(player.current, "Use the code words, preferably in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
+			to_chat(M, "Listen for the code words, preferably in the order provided, during regular conversations to identify agents in need. Proceed with caution, however, as everyone is a potential foe.")
 
 /decl/special_role/traitor/equip_role(var/mob/living/carbon/human/player)
 


### PR DESCRIPTION
…ong with telecrystals and proper messages for what code words are and stored to memory

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The pull request is to add methods so that candidates who become traitor mid round are properly equiped with an uplink and given the code phrases that are saved to memory. This only procs for both the original traitor(s) and the candidate(s) if one of the candidate(s) becomes a mid round traitor.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

There was a bug noted that the mid round traitor was not being given neither the code words nor uplink and could not be of use to the traitor as they had no way of contacting or helping.

## Authorship
<!-- Describe original authors of changes to credit them. -->
EvilDrCoconut

## Changelog
:cl:
bugfix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->