### PR TITLE
Ministation2 fixes 2 19 2024

### DIFF
--- a/maps/ministation2/ministation-1.dmm
+++ b/maps/ministation2/ministation-1.dmm
@@ -1961,6 +1961,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
 	},
+/obj/machinery/fabricator/micro/bartender{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cafe)
 "jT" = (

--- a/maps/ministation2/ministation-2.dmm
+++ b/maps/ministation2/ministation-2.dmm
@@ -776,6 +776,8 @@
 /obj/item/twohanded/spear/diamond,
 /obj/item/shield/buckler,
 /obj/item/gps/explorer,
+/obj/item/clothing/head/helmet/space/void/expedition/scav,
+/obj/item/clothing/suit/space/void/expedition/scav,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "cJ" = (
@@ -4258,6 +4260,8 @@
 /obj/item/twohanded/spear/diamond,
 /obj/item/shield/buckler,
 /obj/item/gps/explorer,
+/obj/item/clothing/head/helmet/space/void/expedition/scav,
+/obj/item/clothing/suit/space/void/expedition/scav,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "zT" = (

--- a/maps/ministation2/ministation-3.dmm
+++ b/maps/ministation2/ministation-3.dmm
@@ -29898,8 +29898,8 @@ cw
 cw
 cw
 cw
-aa
-aa
+cw
+cw
 aa
 aa
 aa
@@ -30155,8 +30155,8 @@ cw
 cw
 cw
 cw
-aa
-aa
+cw
+cw
 aa
 aa
 aa
@@ -30412,8 +30412,8 @@ cw
 cw
 cw
 cw
-aa
-aa
+cw
+cw
 aa
 aa
 aa


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Microlathe added for the bartender, Missing voidsuits were readded to R&D's EVA, Fixed the leak in the north west maint corridor
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This will make the map function as well as make bar RP better, also science will be able to organize away teams
## Authorship
<!-- Describe original authors of changes to credit them. -->
Devchord
## Changelog
:cl:
add: Added voidsuits to science eva lockers
add: Added microlathe to bar
bugfix: fixed missing tiles above the maint corridors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->