### PR TITLE
New drinks, map changes

### DIFF
--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -550,6 +550,11 @@
 	glass_desc = "A glass of refreshing cola."
 	glass_special = list(DRINK_FIZZ)
 
+/decl/material/liquid/drink/cola/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
+	if(prop.reagents.has_reagent(/decl/material/liquid/drink/milk))
+		. = "pilk"
+	. = ..(prop, .)
+
 /decl/material/liquid/drink/citrussoda
 	name = "citrus soda"
 	lore_text = "Fizzy and tangy."
@@ -878,3 +883,15 @@
 
 	glass_name = "Compote"
 	glass_desc = "Traditional dessert drink made from fruits or berries. Grandma would be proud."
+
+/decl/material/liquid/drink/horchata
+	name = "horchata"
+	lore_text = "A traditional mexican drink made from rice, milk, vanilla, and cinnamon."
+	taste_description = "refreshing vanilla and cinnamon"
+	color = "#d6c9be"
+	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
+	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	uid = "chem_drink_horchata"
+
+	glass_name = "Horchata"
+	glass_desc = "A traditional mexican drink made from rice, milk, vanilla, and cinnamon."

--- a/code/modules/reagents/reactions/reaction_recipe.dm
+++ b/code/modules/reagents/reactions/reaction_recipe.dm
@@ -115,3 +115,10 @@
 	required_reagents = list(/decl/material/liquid/nutriment/rice = 10, /decl/material/liquid/drink/tea/green = 1)
 	result_amount = 10
 	mix_message = "The tea mingles with the rice."
+
+/decl/chemical_reaction/recipe/horchata
+	name = "Horchata"
+	result = /decl/material/liquid/drink/horchata
+	required_reagents = list(/decl/material/liquid/nutriment/rice = 2, /decl/material/liquid/drink/milk = 2, /decl/material/liquid/drink/syrup/vanilla = 1, /decl/material/solid/cinnamon = 1)
+	result_amount = 6
+	mix_message = "The ingredients combine to create a refreshing white beverage"

--- a/maps/_map_include.dm
+++ b/maps/_map_include.dm
@@ -2,3 +2,4 @@
 	This is a dummy file to act as a marker point for dm.sh to insert its maps at.
 	DO NOT MOVE, REMOVE OR RENAME THIS FILE WITHOUT FIXING THE SCRIPT OR THINGS WILL BREAK
 */
+s

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -2333,6 +2333,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
+"hF" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	req_access = list("ACCESS_ENGINEERING")
+	},
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/engineering,
+/obj/item/clothing/under/hazardjumpsuit/yinglet,
+/obj/item/storage/backpack/dufflebag/eng,
+/obj/item/storage/backpack/dufflebag/eng,
+/obj/item/clothing/shoes/sandal/yinglet,
+/obj/item/clothing/under/avian_smock/engineering,
+/turf/simulated/floor/tiled/steel_grid,
+/area/ministation/engine)
 "hG" = (
 /obj/machinery/power/smes/buildable/max_cap_in_out{
 	capacity = 5e+009;
@@ -5261,6 +5273,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/bin/ministation,
+/obj/item/clothing/suit/yingtrashbag,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
 "tP" = (
@@ -6759,7 +6772,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/weeb,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
 "Ak" = (
@@ -7967,7 +7980,7 @@
 /area/ministation/engine)
 "Ec" = (
 /obj/machinery/light,
-/obj/machinery/vending/snack{
+/obj/machinery/vending/coffee{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -12169,6 +12182,7 @@
 /area/ministation/engine)
 "Qq" = (
 /obj/structure/closet/crate/bin/ministation,
+/obj/item/clothing/suit/yingtrashbag,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "Qt" = (
@@ -14503,6 +14517,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing/mapped,
+/obj/item/clothing/suit/yingtrashbag/blue{
+	name = "shiny trashbag"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "ZL" = (
@@ -48144,8 +48161,8 @@ av
 av
 nz
 nz
-EX
-EX
+hF
+hF
 EX
 XQ
 FV

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -111,12 +111,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/medical{
-	pixel_x = -2
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
+/obj/machinery/vending/lavatory,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "ax" = (
@@ -809,6 +807,13 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
+"dV" = (
+/obj/item/mollusc/barnacle{
+	pixel_x = -13;
+	pixel_y = 10
+	},
+/turf/space,
+/area/space)
 "dW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1135,6 +1140,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/security)
+"fB" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera/network/medbay{
+	dir = 1;
+	req_access = list("ACCESS_CAMERAS");
+	name = "nursery"
+	},
+/obj/random/toy,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1367,6 +1387,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/ministation/security)
+"gY" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/yinglet_nest{
+	pixel_y = 9;
+	pixel_x = -1
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	current_health = 1e+007
+	},
+/obj/effect/floor_decal/carpet/red{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "ha" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1594,6 +1631,7 @@
 /obj/item/telebaton,
 /obj/item/clothing/under/yinglet/scout,
 /obj/item/clothing/shoes/sandal/yinglet,
+/obj/item/clothing/under/avian_smock/security,
 /turf/simulated/floor/tiled,
 /area/ministation/security)
 "hO" = (
@@ -1817,7 +1855,6 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
 "ix" = (
-/obj/machinery/door/airlock/medical,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1826,6 +1863,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass/medical{
+	name = "Operating Room 2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -2273,6 +2313,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cafe)
 "kv" = (
@@ -2485,6 +2526,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"lk" = (
+/obj/item/chems/chem_disp_cartridge/amphetamines,
+/obj/random/useful,
+/turf/simulated/floor/plating,
+/area/ministation/maint/l2central)
 "ln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/ss13/l12,
@@ -2826,6 +2872,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"mV" = (
+/obj/structure/railing/mapped,
+/obj/structure/table,
+/obj/item/chems/spray/cleaner{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/trash/mollusc_shell/clam{
+	pixel_y = 1;
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "mW" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable{
@@ -2862,6 +2921,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"nn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "no" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -2984,6 +3049,9 @@
 /area/ministation/security)
 "nX" = (
 /obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3117,6 +3185,9 @@
 "oE" = (
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/secmaint)
@@ -3261,6 +3332,7 @@
 /area/ministation/hall/w2)
 "pu" = (
 /obj/structure/closet/crate/bin/ministation,
+/obj/item/clothing/suit/yingtrashbag,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
 "pw" = (
@@ -3317,37 +3389,35 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
 "pF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/ministation/medical)
+/obj/random/contraband,
+/obj/structure/skele_stand,
+/turf/simulated/floor/plating,
+/area/ministation/maint/l2central)
 "pG" = (
-/obj/structure/sign/plaque/diploma/medical{
-	pixel_y = 31
+/obj/item/stool/padded,
+/obj/structure/sign/warning/nosmoking_2{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/ministation/medical)
 "pH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/item/stool/padded,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/stool/padded,
-/obj/structure/sign/warning/nosmoking_2{
-	pixel_y = 32
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue2,
 /area/ministation/medical)
 "pI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/item/stool/padded,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
 	},
 /obj/machinery/status_display{
 	pixel_y = 33;
@@ -3356,10 +3426,11 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "pJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "pK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3372,9 +3443,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "pL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/body_scanconsole{
 	dir = 8
@@ -3398,9 +3466,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "pN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/vending/medical{
 	pixel_x = -2
 	},
@@ -3412,10 +3477,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "pO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall/r_wall,
 /area/ministation/medical)
 "pP" = (
 /obj/structure/table,
@@ -3483,6 +3545,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/detective)
+"qe" = (
+/obj/effect/floor_decal/carpet/red{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "qf" = (
 /turf/simulated/wall,
 /area/ministation/maint/l2centrals)
@@ -3498,17 +3566,11 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/l2central)
 "qn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/book/skill/medical,
 /turf/simulated/floor/carpet/blue2,
 /area/ministation/medical)
 "qo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/newspaper,
 /obj/item/chems/spray/cleaner,
@@ -3522,18 +3584,19 @@
 /area/ministation/medical)
 "qq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue2,
 /area/ministation/medical)
 "qr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "qs" = (
@@ -3546,6 +3609,9 @@
 	autoset_access = 0;
 	id_tag = "medleave";
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -3620,6 +3686,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"qJ" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/ministation/medical)
 "qL" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "l2_central_north_sensor";
@@ -3701,12 +3771,16 @@
 /area/ministation/medical)
 "ra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/carpet/blue2,
 /area/ministation/medical)
 "rb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -3733,11 +3807,17 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "re" = (
 /obj/abstract/landmark/start{
 	name = "Medical Doctor"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -3746,15 +3826,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "rg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "conpipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -3921,6 +4001,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "rL" = (
@@ -4066,6 +4147,7 @@
 	id_tag = "quarantine";
 	name = "quarantine shutters"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "sk" = (
@@ -4506,6 +4588,13 @@
 	},
 /turf/simulated/floor/tiled/stone,
 /area/ministation/hall/e2)
+"tB" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "tD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6703,6 +6792,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
+"AF" = (
+/obj/structure/lattice,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ministation/medical)
 "AG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6815,7 +6909,6 @@
 /turf/simulated/floor/carpet/red,
 /area/ministation/security)
 "Bu" = (
-/obj/machinery/door/airlock/medical,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6824,6 +6917,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass/medical{
+	name = "Operating Room 1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
@@ -6835,6 +6931,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/item/clothing/suit/yingtrashbag,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
 "Bw" = (
@@ -6901,6 +6998,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ministation/cafe)
+"BL" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/open,
+/area/ministation/hall/w2)
 "BN" = (
 /obj/machinery/light{
 	icon_state = "tube1"
@@ -7246,6 +7347,14 @@
 "Dx" = (
 /turf/simulated/floor/carpet/red,
 /area/ministation/security)
+"Dz" = (
+/obj/machinery/door/airlock/hatch/maintenance{
+	req_access = list("ACCESS_MAINT");
+	autoset_access = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/ministation/medical/nursery)
 "DA" = (
 /obj/machinery/button/blast_door{
 	req_access = list("ACCESS_HEAD_OF_SECURITY");
@@ -7329,6 +7438,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"DS" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/space_heater{
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced{
+	current_health = 1e+007
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "DY" = (
 /obj/machinery/camera/network/security{
 	dir = 4
@@ -7527,6 +7649,14 @@
 	},
 /turf/simulated/floor/carpet/blue3,
 /area/ministation/security)
+"EZ" = (
+/obj/effect/floor_decal/carpet/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "Fa" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/gas/clown_hat,
@@ -7538,6 +7668,13 @@
 /obj/item/poster,
 /turf/simulated/floor/plating,
 /area/ministation/maint/hydromaint)
+"Fe" = (
+/obj/item/toy/plushie,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "Fh" = (
 /obj/structure/flora/bush,
 /turf/simulated/floor/grass,
@@ -7549,6 +7686,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/security)
+"Fk" = (
+/obj/machinery/door/airlock/medical{
+	name = "Nursery"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/ministation/medical/nursery)
 "Fn" = (
 /obj/structure/closet,
 /obj/random/maintenance,
@@ -7566,6 +7712,9 @@
 /area/ministation/medical)
 "Fr" = (
 /obj/structure/flora/pottedplant/flower,
+/obj/structure/sign/plaque/diploma/medical{
+	pixel_y = 31
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "Ft" = (
@@ -7825,6 +7974,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"Ha" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/yinglet_nest{
+	pixel_y = 8;
+	pixel_x = -1
+	},
+/obj/machinery/door/window/brigdoor/southright,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/red,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
+"Hb" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/ministation/medical/nursery)
 "Hd" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/steel,
@@ -7853,6 +8019,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
+"Hs" = (
+/obj/random/drinkbottle,
+/turf/simulated/floor/plating,
+/area/ministation/maint/l2central)
 "Ht" = (
 /obj/machinery/light{
 	dir = 1
@@ -8532,6 +8702,11 @@
 "KS" = (
 /turf/simulated/floor/tiled/dark,
 /area/ministation/security)
+"KU" = (
+/obj/item/toy/plushie/squid/orange,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "KV" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	req_access = list("ACCESS_SECURITY");
@@ -8583,6 +8758,13 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/carpet/red,
 /area/ministation/security)
+"Ll" = (
+/obj/item/stool/padded,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "Lm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8861,6 +9043,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"MM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "MQ" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning{
@@ -8874,7 +9063,7 @@
 /area/ministation/hall/w2)
 "MT" = (
 /obj/structure/stairs/long/west,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/ministation/medical)
 "MU" = (
 /obj/structure/filing_cabinet/chestdrawer,
@@ -8892,6 +9081,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
+"Nb" = (
+/obj/structure/bed/chair/armchair/black{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "Ne" = (
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -9078,6 +9277,13 @@
 /obj/item/cash/scavbucks,
 /turf/simulated/floor/plating,
 /area/ministation/maint/l2centraln)
+"NW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "NX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
@@ -9139,6 +9345,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"On" = (
+/obj/item/poster,
+/turf/simulated/floor/plating,
+/area/ministation/maint/secmaint)
 "Oo" = (
 /obj/machinery/beehive,
 /turf/simulated/floor/grass,
@@ -9164,6 +9374,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/ministation/security)
+"Or" = (
+/obj/structure/railing/mapped,
+/obj/structure/table,
+/obj/item/mollusc/clam{
+	pixel_y = 4
+	},
+/obj/item/book/fluff/anomaly_testing{
+	pixel_y = 7;
+	pixel_x = 7
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "Ou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9181,6 +9403,12 @@
 	},
 /turf/simulated/floor/carpet/blue3,
 /area/ministation/security)
+"OD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/ministation/maint/secmaint)
 "OF" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9227,6 +9455,7 @@
 /area/ministation/security)
 "OL" = (
 /obj/structure/closet/secure_closet/medical1,
+/obj/item/clothing/under/avian_smock/worker,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "ON" = (
@@ -9342,6 +9571,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l2centraln)
+"Pn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "Po" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -9526,6 +9760,7 @@
 /obj/item/telebaton,
 /obj/item/clothing/under/yinglet/scout,
 /obj/item/clothing/shoes/sandal/yinglet,
+/obj/item/clothing/under/avian_smock/security,
 /turf/simulated/floor/tiled,
 /area/ministation/security)
 "Qh" = (
@@ -9561,6 +9796,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/hall/w2)
+"Qr" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/space_heater{
+	pixel_y = 5
+	},
+/obj/structure/window/reinforced{
+	current_health = 1e+007
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "Qs" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -9683,6 +9934,18 @@
 /obj/structure/flora/bush/sparsegrass,
 /turf/simulated/floor/grass,
 /area/ministation/security)
+"Ri" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/yinglet_nest{
+	pixel_y = 10
+	},
+/obj/machinery/door/window/brigdoor/southright,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/red,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "Rk" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -10114,6 +10377,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"TH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/ministation/medical/nursery)
 "TM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "sqm_vent";
@@ -10244,12 +10513,8 @@
 /turf/simulated/wall,
 /area/ministation/enclave/gatehouse)
 "Up" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/poster,
-/turf/simulated/floor/plating,
-/area/ministation/maint/secmaint)
+/turf/simulated/wall/r_wall,
+/area/ministation/medical/nursery)
 "Ur" = (
 /obj/structure/table/woodentable/mahogany,
 /turf/simulated/floor/carpet/red,
@@ -10303,6 +10568,7 @@
 	},
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/item/clothing/under/avian_smock/worker,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "UJ" = (
@@ -10513,15 +10779,12 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hydro)
 "VJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/body_scan_display{
+	pixel_y = 20;
+	id_tag = "mediscanner1"
 	},
 /obj/machinery/bodyscanner{
 	dir = 8;
-	id_tag = "mediscanner1"
-	},
-/obj/machinery/body_scan_display{
-	pixel_y = 20;
 	id_tag = "mediscanner1"
 	},
 /turf/simulated/floor/tiled/white,
@@ -10654,6 +10917,14 @@
 /obj/structure/stairs/long/east,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/w2)
+"Wp" = (
+/obj/structure/flora/pottedplant/floorleaf,
+/obj/machinery/light{
+	dir = 8;
+	flickering = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -10768,8 +11039,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/hall/e2)
@@ -10881,12 +11152,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"Xz" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/yinglet_nest{
+	pixel_y = 10;
+	pixel_x = 1
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	current_health = 1e+007
+	},
+/obj/effect/floor_decal/carpet/red{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "XA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
+/area/ministation/medical)
+"XC" = (
+/turf/simulated/floor/plating,
 /area/ministation/medical)
 "XE" = (
 /obj/machinery/light,
@@ -10977,6 +11268,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/Arrival)
+"Yu" = (
+/obj/item/book/skill/organizational/literacy/basic{
+	pixel_x = 1
+	},
+/obj/item/book/skill/organizational/literacy/basic{
+	pixel_y = 6;
+	pixel_x = 3
+	},
+/obj/effect/floor_decal/carpet/red{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/medical/nursery)
 "Yv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11013,6 +11317,13 @@
 	},
 /turf/space,
 /area/space)
+"YD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/medical)
 "YF" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -11039,11 +11350,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/ministation/security)
 "YH" = (
-/obj/random/maintenance,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /obj/structure/closet,
+/obj/random/maintenance,
 /obj/item/poster,
 /turf/simulated/floor/plating,
-/area/ministation/maint/secmaint)
+/area/ministation/medical/nursery)
 "YS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -11092,6 +11412,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ministation/cafe)
+"Ze" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ministation/maint/secmaint)
 "Zh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/vending/cigarette,
@@ -40122,8 +40451,8 @@ lC
 lC
 lC
 ox
-HO
-HO
+pF
+Hs
 cO
 ER
 or
@@ -40379,7 +40708,7 @@ ox
 ox
 ox
 ox
-HO
+lk
 cO
 cO
 cO
@@ -44239,7 +44568,7 @@ HO
 rt
 kZ
 NC
-NC
+BL
 kZ
 mH
 sD
@@ -50144,7 +50473,7 @@ ob
 cY
 tQ
 ef
-ef
+zo
 JZ
 qa
 to
@@ -50399,9 +50728,9 @@ cY
 uQ
 cT
 cY
-Rx
+tQ
 oE
-ef
+OD
 JZ
 ae
 UB
@@ -50656,8 +50985,8 @@ cY
 aa
 aa
 aa
-Rx
-ef
+tQ
+Ze
 ef
 Rx
 oz
@@ -50913,12 +51242,12 @@ cY
 aa
 aa
 aa
-Rx
+tQ
 YH
-Up
+On
 ef
 wd
-pD
+nn
 RU
 pD
 FF
@@ -51170,14 +51499,14 @@ cY
 aa
 aa
 aa
-Rx
-Rx
-Rx
-Rx
+tQ
+Up
+Dz
+tQ
 oz
 pe
-oF
 jR
+qY
 lJ
 oz
 BS
@@ -51427,13 +51756,13 @@ cY
 aa
 aa
 aa
-aa
-DI
-aa
-aa
-vK
-pe
-pF
+Up
+DS
+qe
+Yu
+oz
+Ll
+qp
 qn
 qZ
 oz
@@ -51684,13 +52013,13 @@ cY
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-vK
+Up
+Ri
+NW
+Nb
+pO
 Fr
-pF
+qp
 qo
 qY
 rI
@@ -51941,15 +52270,15 @@ DZ
 ad
 ad
 ad
-ad
-ad
-ad
-ad
+Hb
+Ri
+TH
+KU
 oz
 oz
 pG
-qp
 qY
+oF
 pe
 oz
 fC
@@ -52198,12 +52527,12 @@ ad
 aa
 aa
 aa
-aa
-ad
-aa
-aa
-aa
-oz
+Up
+Ha
+Fe
+Pn
+EZ
+Fk
 pH
 qq
 ra
@@ -52455,11 +52784,11 @@ aa
 aa
 aa
 aa
-aa
-ad
-aa
-aa
-aa
+Up
+Qr
+Xz
+gY
+fB
 oz
 pI
 qr
@@ -52712,13 +53041,13 @@ aa
 aa
 aa
 aa
-aa
-ad
-aa
-hp
+Up
+qJ
+pO
+pO
+pO
 oz
 oz
-pJ
 hr
 qs
 oz
@@ -52969,10 +53298,10 @@ aa
 aa
 aa
 aa
-aa
-ad
-aa
-hp
+dV
+AF
+Wp
+Or
 MT
 oz
 VJ
@@ -53227,10 +53556,10 @@ aa
 aa
 aa
 aa
-ad
-aa
-hp
+AF
 pD
+mV
+XC
 oz
 pL
 Kt
@@ -53484,14 +53813,14 @@ aa
 aa
 aa
 aa
-ad
-aa
-hp
+AF
+MM
+tB
 ts
 iJ
-uW
-qu
 pD
+qu
+uW
 rM
 oz
 CD
@@ -53741,14 +54070,14 @@ aa
 aa
 aa
 aa
-ad
-aa
-hp
+AF
+oz
+oz
 oz
 oz
 pN
 qv
-rf
+YD
 rN
 Az
 Jl
@@ -54003,9 +54332,9 @@ oz
 oz
 oz
 ri
-pO
+pD
 rg
-rO
+pJ
 pK
 rO
 Be

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -293,15 +293,18 @@
 /turf/simulated/wall/r_wall,
 /area/ministation/bridge/vault)
 "bi" = (
-/turf/simulated/floor/tiled,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "bl" = (
 /turf/simulated/wall/r_wall,
 /area/ministation/telecomms)
 "bn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
@@ -358,6 +361,7 @@
 /obj/item/arrow,
 /obj/item/cell/crap,
 /obj/item/mollusc/clam,
+/obj/item/toy/plushie/carp/gold,
 /turf/simulated/floor/wood/walnut,
 /area/ministation/bridge)
 "bu" = (
@@ -406,7 +410,10 @@
 /obj/item/stack/material/ingot/mapped/gold,
 /obj/item/stack/material/ingot/mapped/gold,
 /obj/item/storage/belt/champion,
-/turf/simulated/floor/tiled,
+/obj/machinery/light/small/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "bz" = (
 /obj/abstract/landmark/start{
@@ -456,20 +463,14 @@
 /area/ministation/bridge/vault)
 "bE" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/ministation/bridge/vault)
-"bF" = (
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
+"bF" = (
+/obj/machinery/suit_cycler,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "bG" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/clothing/shoes/sandal/yinglet,
@@ -562,7 +563,7 @@
 /obj/item/ammo_magazine/rifle/practice,
 /obj/item/ammo_magazine/rifle/practice,
 /obj/item/ammo_magazine/rifle/practice,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "bV" = (
 /obj/machinery/firealarm{
@@ -2113,7 +2114,9 @@
 	initial_access = null;
 	req_access = list("ACCESS_CAMERAS")
 	},
-/turf/simulated/floor/tiled,
+/obj/item/charge_stick/gold,
+/obj/random/useful,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "iy" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
@@ -4919,8 +4922,17 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo/f3)
 "ym" = (
-/obj/structure/yinglet_nest,
-/turf/simulated/floor/tiled,
+/obj/item/chems/drinks/golden_cup{
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/medal/gold{
+	pixel_y = -2;
+	pixel_x = -10
+	},
+/obj/machinery/light/small/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "yu" = (
 /obj/structure/cable{
@@ -6488,9 +6500,9 @@
 	pixel_y = 25
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "GD" = (
 /turf/open,
@@ -6733,10 +6745,10 @@
 /turf/simulated/floor/wood/yew,
 /area/ministation/court)
 "Iu" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/red{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "Iw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6847,6 +6859,14 @@
 /obj/structure/bookcase/manuals/xenoarchaeology,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Jd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/machinery/light/small/red,
+/turf/simulated/floor/bluegrid,
+/area/ministation/bridge/vault)
 "Jf" = (
 /obj/machinery/light{
 	dir = 1
@@ -6958,7 +6978,7 @@
 	boots = /obj/item/clothing/shoes/magboots;
 	initial_access = list("ACCESS_VAULT")
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "JJ" = (
 /obj/machinery/door/airlock/glass,
@@ -8600,6 +8620,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/bridge)
+"SU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/light/small/red,
+/turf/simulated/floor/bluegrid,
+/area/ministation/bridge/vault)
 "SV" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -8646,7 +8674,10 @@
 	pixel_y = 28
 	},
 /obj/structure/filing_cabinet,
-/turf/simulated/floor/tiled,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/bridge/vault)
 "Tq" = (
 /obj/structure/disposalpipe/segment,
@@ -8879,6 +8910,21 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
+"Uk" = (
+/obj/item/stack/material/ingot/mapped/gold/forty{
+	pixel_y = 8
+	},
+/obj/item/stack/material/ingot/mapped/gold/forty{
+	pixel_x = -9
+	},
+/obj/item/stack/material/ingot/mapped/gold/forty{
+	pixel_x = -9
+	},
+/obj/item/stack/material/ingot/mapped/gold/forty{
+	pixel_x = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/bridge/vault)
 "Ul" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -38976,8 +39022,8 @@ QS
 QS
 QS
 tf
-aa
-aa
+cw
+cw
 Cd
 JK
 Cd
@@ -39233,7 +39279,7 @@ kX
 hS
 xm
 tf
-aa
+cw
 cw
 Cd
 Ie
@@ -44605,8 +44651,8 @@ aa
 bg
 GA
 bn
-bF
 WR
+SU
 bg
 aa
 aa
@@ -45120,7 +45166,7 @@ bg
 iw
 nj
 jE
-jE
+Jd
 bg
 ad
 ad
@@ -45377,7 +45423,7 @@ bg
 JG
 by
 ym
-ym
+Uk
 bg
 ad
 aa
@@ -46719,7 +46765,7 @@ NM
 db
 ae
 cx
-db
+bF
 db
 cI
 ae
@@ -50281,9 +50327,9 @@ cw
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 dw
 dt
@@ -50538,9 +50584,9 @@ cw
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 gJ
 fK
@@ -50795,9 +50841,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 AY
 fK
@@ -51052,9 +51098,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 dv
 Ik
@@ -51309,9 +51355,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 ae
 ae
@@ -51566,9 +51612,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+cw
+cw
+cw
 ae
 YA
 jC
@@ -51824,8 +51870,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 ae
 iP
 Ug
@@ -52081,8 +52127,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 ae
 iP
 Ug
@@ -52338,8 +52384,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 ae
 Ni
 Ru
@@ -52595,8 +52641,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 ae
 CL
 pV

--- a/maps/ministation/ministation_areas.dm
+++ b/maps/ministation/ministation_areas.dm
@@ -251,6 +251,12 @@
 	icon_state = "light_blue"
 	secure = TRUE
 
+/area/ministation/medical/nursery
+	name = "\improper Nursery"
+	area_flags = AREA_FLAG_RAD_SHIELDED
+	icon_state = "green"
+	secure = TRUE
+
 /area/ministation/cryo
 	name = "\improper Medical Cryogenics"
 	req_access = list()


### PR DESCRIPTION
## Description of changes
-Added new drinks Pilk and Horchata
-Added nursery room to medbay
-Added trashbag costumes (including shiny trashbag!) to map
-Added avian smocks to lockers in medbay, engineering, and security
-Expanded medbay-research stairway area
-Various minor mapping tweaks

## Why and what will this PR improve
More drinks are always good
Aleuph requested the nursery, its better to have the eggs in medbay than in a room with a nuclear bomb
Trashbag costumes were created ages ago, but were inaccessible due to not being present on maps
There was previously no mapped avian clothing
Medbay-research stairway area is very cramped, this has caused serious z-level lag due to the crowd-crush
Various tweaks such as access to previously unmapped vendor types, reduction of resources in medbay, better surgery-spectating

## Changelog
:cl:
add: Pilk and recipe alias
add: Horchata and chemical reaction
add: Nursery room in medbay
add: Trashbag costumes in bins (including secret, shiny trashbag!)
add: Relevant Avian smocks to lockers in medbay, engineering, and security)
add: carp plush in captains quarters
tweak: replaced eggs in vault with treasure
tweak: expanded medbay-research stairway area
tweak: replaced a redundant food dispenser with the weeb variant
tweak: changed the surgery doors to have windows
balance: removed one of the chemistry dispensers in medbay (replaced with lavatory dispenser, open to suggestions for a different type)
/:cl:

