### PR TITLE
Minor tweaks to (mostly) science

### DIFF
--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -6247,9 +6247,6 @@
 /turf/space,
 /area/space)
 "vv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -196,10 +196,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ministation/engine)
 "aL" = (
-/obj/machinery/power/apc{
-	name = "_South APC";
-	pixel_y = -24
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -209,8 +205,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
+	},
 /turf/simulated/floor/plating,
-/area/ministation/dorms)
+/area/ministation/maint/l1ne)
 "aM" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1
@@ -1193,6 +1195,9 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1central)
 "dV" = (
@@ -1570,8 +1575,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ministation/dorms)
 "fe" = (
-/turf/simulated/wall/r_wall,
-/area/ministation/hall/s1)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "fg" = (
 /obj/structure/window/reinforced{
 	current_health = 1e+007
@@ -2361,13 +2370,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "ht" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3110,9 +3118,6 @@
 /area/ministation/cargo)
 "jY" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3331,15 +3336,17 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ministation/dorms)
 "kM" = (
-/obj/machinery/power/apc/high{
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 20
+	name = "_North APC";
+	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/ministation/hall/n)
+/turf/simulated/floor/tiled,
+/area/ministation/cargo)
 "kN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3565,6 +3572,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
@@ -4115,6 +4125,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "nj" = (
@@ -4137,9 +4150,6 @@
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
 "nk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -4463,6 +4473,12 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled,
 /area/ministation/janitor)
+"oJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/ministation/maint/l1ne)
 "oK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4619,16 +4635,13 @@
 /turf/simulated/floor/plating,
 /area/ministation/engineroom)
 "pz" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/ministation/cargo)
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n)
 "pA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped{
@@ -4740,12 +4753,14 @@
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "qa" = (
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/abstract/landmark/start{
+	name = "Recruit"
 	},
-/turf/simulated/floor/plating,
-/area/ministation/cargo)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/dorms)
 "qb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
@@ -5005,9 +5020,6 @@
 /area/ministation/maint/l1ne)
 "qN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
 "qO" = (
@@ -5157,9 +5169,6 @@
 /area/ministation/hall/s1)
 "rn" = (
 /obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1central)
 "rq" = (
@@ -5348,12 +5357,6 @@
 /turf/simulated/floor/plating,
 /area/ministation/enclave/scikitchen)
 "sh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -5362,6 +5365,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
@@ -5732,7 +5741,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/ministation/trash)
+/area/ministation/maint/l1central)
 "tD" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/effect/floor_decal/corner/yellow{
@@ -6191,7 +6200,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/ministation/hall/s1)
+/area/ministation/maint/l1central)
 "vh" = (
 /obj/machinery/door/firedoor{
 	dir = 8
@@ -6249,6 +6258,9 @@
 "vv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
@@ -6484,7 +6496,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
@@ -6552,6 +6564,10 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/cargo)
@@ -6779,7 +6795,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
@@ -6846,6 +6862,9 @@
 /area/ministation/atmospherics)
 "xQ" = (
 /obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "xR" = (
@@ -7460,6 +7479,9 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
 "AA" = (
@@ -7965,7 +7987,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/ministation/hall/n)
+/area/ministation/maint/l1central)
 "Cm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
@@ -8331,17 +8353,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/high{
-	dir = 1;
-	pixel_y = 20
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/ministation/hall/s1)
+/area/ministation/maint/westatmos)
 "Dx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9767,6 +9782,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "GM" = (
@@ -10434,21 +10452,17 @@
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
 "IM" = (
-/obj/machinery/power/apc{
-	name = "_South APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
@@ -10595,14 +10609,18 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/eastatmos)
 "Jk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled,
-/area/ministation/hall/n)
+/area/ministation/hall/s1)
 "Jl" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10838,9 +10856,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11122,6 +11137,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "_South APC";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
@@ -11631,6 +11653,9 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
 "LZ" = (
@@ -11810,6 +11835,14 @@
 	name = "Recruit"
 	},
 /obj/item/stool/padded,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "_North APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/dorms)
 "MC" = (
@@ -12365,16 +12398,6 @@
 /turf/simulated/floor/plating,
 /area/ministation/ai_sat)
 "On" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/high{
-	dir = 1;
-	pixel_y = 20
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12383,6 +12406,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1central)
@@ -12502,7 +12528,12 @@
 "OK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
@@ -12510,7 +12541,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/ministation/hall/n)
+/area/ministation/maint/l1central)
 "OO" = (
 /obj/machinery/door/airlock/external/glass{
 	autoset_access = 0;
@@ -13481,6 +13512,9 @@
 	dir = 1;
 	icon_state = "warning"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "RS" = (
@@ -13515,9 +13549,6 @@
 /turf/simulated/floor/wood/yew,
 /area/ministation/engine)
 "Sa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/binary/pump/on{
 	target_pressure = 200;
 	dir = 1
@@ -14440,6 +14471,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
 "VO" = (
@@ -14860,6 +14894,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s1)
@@ -15353,6 +15390,9 @@
 /area/ministation/cargo)
 "Zl" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l1ne)
 "Zm" = (
@@ -45207,14 +45247,14 @@ gP
 wB
 au
 NX
-jh
+MX
 MX
 MX
 jd
 MX
 MX
 MX
-jh
+MX
 Bu
 jh
 jh
@@ -45460,18 +45500,18 @@ fu
 au
 au
 au
-gP
+kM
 hs
 au
 NX
-jh
+MX
 Yx
 pZ
 WF
 ZK
 uM
 do
-jh
+MX
 cw
 qd
 dw
@@ -45720,17 +45760,17 @@ au
 gP
 ht
 au
-pz
-jh
+NX
+MX
 AN
 nG
 Os
 qW
 WR
 TJ
-jh
-jh
-jh
+MX
+MX
+MX
 dF
 di
 di
@@ -45976,9 +46016,9 @@ fS
 gq
 gP
 JV
-qa
+el
 rn
-jh
+MX
 xX
 CL
 ez
@@ -46235,7 +46275,7 @@ gO
 hu
 au
 NX
-jh
+MX
 eB
 hA
 rT
@@ -46244,7 +46284,7 @@ gg
 lB
 MX
 MX
-jh
+MX
 On
 di
 dM
@@ -46492,7 +46532,7 @@ Ia
 Lq
 di
 zJ
-jh
+MX
 RH
 rT
 qG
@@ -46757,7 +46797,7 @@ hf
 Gd
 Kz
 MX
-kM
+NX
 nk
 jY
 di
@@ -46795,7 +46835,7 @@ mZ
 ms
 DD
 Dw
-fe
+av
 AR
 av
 av
@@ -47050,7 +47090,7 @@ SC
 uQ
 xw
 ms
-uK
+ms
 qP
 ms
 Ed
@@ -47271,8 +47311,8 @@ jo
 fz
 mr
 OK
-Rs
-Rs
+fz
+fz
 sh
 Rs
 qO
@@ -47530,7 +47570,7 @@ iN
 ll
 gQ
 gQ
-Jk
+ij
 gQ
 gQ
 iN
@@ -47785,8 +47825,8 @@ iM
 iM
 na
 ni
-OY
-uY
+pz
+fe
 LY
 uY
 OY
@@ -48074,7 +48114,7 @@ aV
 aV
 aV
 Rr
-aV
+sC
 aV
 Ox
 aV
@@ -48331,7 +48371,7 @@ QG
 ui
 Ib
 ui
-ui
+Jk
 eZ
 Hg
 ui
@@ -48539,7 +48579,7 @@ MK
 OG
 eu
 nS
-eu
+zW
 fU
 fU
 es
@@ -48593,8 +48633,8 @@ ms
 ms
 ms
 hn
-Dt
-Dt
+ms
+ms
 Eh
 Ex
 av
@@ -48796,7 +48836,7 @@ pa
 AF
 qr
 qM
-eu
+zW
 SE
 gX
 xm
@@ -48850,7 +48890,7 @@ Cn
 Wy
 hU
 ak
-Je
+av
 av
 av
 av
@@ -49050,10 +49090,10 @@ eu
 eu
 Xl
 vv
-AF
+oJ
 Zl
 IM
-eu
+zW
 MB
 jO
 tU
@@ -49311,7 +49351,7 @@ Sa
 qN
 ws
 Az
-gX
+qa
 FM
 Bx
 MF
@@ -49819,11 +49859,11 @@ aa
 aa
 zW
 zW
-eu
-eu
-eu
+zW
+zW
+zW
 VJ
-eu
+zW
 zW
 zW
 rH

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -2304,16 +2304,24 @@
 /area/ministation/cafe)
 "jT" = (
 /obj/structure/table,
-/obj/item/hand_labeler,
+/obj/item/hand_labeler{
+	pixel_y = 11;
+	pixel_x = -6
+	},
 /obj/item/radio/intercom{
 	name = "Common Channel";
 	pixel_y = 25
 	},
-/obj/item/storage/pill_bottle,
+/obj/item/storage/pill_bottle{
+	pixel_x = -7
+	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/eftpos,
+/obj/item/eftpos{
+	pixel_y = 5;
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "jU" = (
@@ -4217,10 +4225,21 @@
 /area/ministation/medical)
 "rM" = (
 /obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/bruise_pack{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 1
+	},
+/obj/item/stack/medical/advanced/bruise_pack{
+	pixel_y = 8;
+	pixel_x = 8
+	},
 /obj/machinery/status_display{
 	pixel_y = -29
 	},
@@ -5486,13 +5505,20 @@
 /area/ministation/cafe)
 "vH" = (
 /obj/structure/table,
-/obj/item/chems/dropper,
-/obj/item/storage/box/syringes,
-/obj/item/mollusc/clam,
+/obj/item/storage/box/syringes{
+	pixel_y = 8;
+	pixel_x = 11
+	},
+/obj/item/mollusc/clam{
+	pixel_y = 2
+	},
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 11;
+	pixel_x = -5
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "vJ" = (
@@ -6246,14 +6272,22 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder/juicer,
 /obj/item/chems/glass/beaker,
+/obj/item/chems/dropper{
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/obj/item/book/manual/chemistry_recipes{
+	pixel_x = -12
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "yc" = (
 /obj/structure/table,
 /obj/machinery/reagent_temperature/cooler,
-/obj/item/book/manual/chemistry_recipes,
-/obj/item/modular_computer/holotablet/wide,
-/obj/item/storage/pill_bottle/antidepressants,
+/obj/item/storage/pill_bottle/antidepressants{
+	pixel_x = 16;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "ye" = (
@@ -6472,16 +6506,18 @@
 /area/ministation/medical)
 "yJ" = (
 /obj/structure/table,
-/obj/item/gun/launcher/syringe,
+/obj/item/gun/launcher/syringe{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /obj/item/flashlight/pen,
 /obj/item/flashlight/pen,
-/obj/item/clothing/suit/straight_jacket,
 /obj/item/chems/hypospray/vial{
 	desc = "One of the first hyposprays ever made. Supposedly only a handful exist.";
 	name = "prototype hypospray";
-	origin_tech = null
+	origin_tech = null;
+	pixel_x = 6
 	},
-/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "yK" = (
@@ -6667,7 +6703,10 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/chems/spray/cleaner,
+/obj/item/chems/spray/cleaner{
+	pixel_x = 4;
+	pixel_y = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -6675,6 +6714,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/item/clothing/suit/straight_jacket,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "zv" = (
@@ -8405,6 +8445,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/modular_computer/holotablet/wide,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "HJ" = (
@@ -10672,7 +10713,10 @@
 /obj/structure/table,
 /obj/item/storage/belt/medical/emt,
 /obj/item/bodybag/rescue,
-/obj/item/auto_cpr,
+/obj/item/auto_cpr{
+	pixel_y = 6;
+	pixel_x = 3
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "Td" = (
@@ -11981,6 +12025,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
 /area/ministation/medical)
 "ZX" = (

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -8017,7 +8017,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/ministation/medical/nursery)
 "Fn" = (
 /obj/structure/closet,

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -9293,7 +9293,7 @@
 	req_access = list("ACCESS_CAMERAS")
 	},
 /obj/machinery/recharger/wallcharger{
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -350,6 +350,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/item/toy/plushie/carp/gold,
 /turf/simulated/floor/carpet/red,
 /area/ministation/bridge)
 "bs" = (
@@ -363,18 +364,20 @@
 /turf/simulated/floor/wood/walnut,
 /area/ministation/bridge)
 "bt" = (
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 12;
+	pixel_x = 5
+	},
 /obj/structure/table/woodentable/mahogany,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/item/gun/launcher/crossbow,
-/obj/item/arrow,
-/obj/item/arrow,
 /obj/item/cell/crap,
-/obj/item/mollusc/clam,
-/obj/item/toy/plushie/carp/gold,
+/obj/item/mollusc/clam{
+	pixel_x = -3;
+	pixel_y = 1
+	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/bridge)
 "bu" = (
@@ -491,6 +494,9 @@
 /obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/captain,
 /obj/item/stamp/captain,
 /obj/item/clothing/shoes/sandal/yinglet,
+/obj/item/arrow,
+/obj/item/arrow,
+/obj/item/gun/launcher/crossbow,
 /turf/simulated/floor/carpet/red,
 /area/ministation/bridge)
 "bH" = (
@@ -509,7 +515,9 @@
 /area/ministation/bridge)
 "bI" = (
 /obj/structure/table/woodentable/mahogany,
-/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/modular_computer/tablet/lease/preset/command{
+	pixel_y = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -834,17 +842,14 @@
 	},
 /area/ministation/telecomms)
 "cQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room"
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "cU" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -879,11 +884,8 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
 "cZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/item/stool,
+/turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "da" = (
 /obj/structure/window/basic/full,
@@ -1160,9 +1162,12 @@
 /turf/simulated/floor/plating,
 /area/ministation/shuttle/outgoing)
 "ek" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/space)
+/obj/machinery/vending/sovietsoda,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1176,13 +1181,17 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "eq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "er" = (
 /obj/structure/transit_tube{
@@ -1205,19 +1214,11 @@
 /turf/simulated/floor/tiled,
 /area/ministation/court)
 "ex" = (
-/obj/machinery/button/mass_driver{
-	id_tag = "toxinsdriver";
-	pixel_y = 24
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "ey" = (
 /obj/structure/window/reinforced{
@@ -1331,15 +1332,14 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "eU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "eV" = (
@@ -1419,13 +1419,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "fc" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/robotics,
-/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/science,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/item/clothing/shoes/sandal/yinglet,
+/obj/structure/flora/pottedplant/tropical,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "fd" = (
@@ -2175,19 +2172,11 @@
 /area/ministation/science)
 "iq" = (
 /obj/effect/decal/cleanable/filth,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/ministation/court)
+/area/ministation/maint/l3ne)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2319,15 +2308,8 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "jd" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/flora/pottedplant/aquatic,
+/turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jm" = (
 /obj/machinery/door/blast/regular{
@@ -2342,6 +2324,11 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar/red,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jo" = (
@@ -2361,10 +2348,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jq" = (
@@ -2629,6 +2612,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "ko" = (
@@ -2647,6 +2631,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kq" = (
@@ -2801,8 +2786,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass/science{
-	autoset_access = 0;
-	req_access = list("ACCESS_ROBOTICS")
+	autoset_access = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2822,33 +2806,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "kS" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3003,9 +2980,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "lw" = (
@@ -3017,10 +2991,6 @@
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -3053,6 +3023,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "lC" = (
@@ -3065,6 +3038,9 @@
 /obj/structure/sign/department/xenoflora{
 	pixel_y = -32
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "lD" = (
@@ -3075,11 +3051,22 @@
 	dir = 1;
 	pixel_y = -23
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "lE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = null;
+	name = "_South APC";
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -3360,9 +3347,8 @@
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "mV" = (
-/obj/structure/table,
-/obj/machinery/doppler_array,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
 /area/ministation/science)
 "mW" = (
 /obj/structure/cable{
@@ -3650,6 +3636,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"oA" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small/red{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "oB" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/green/full,
@@ -3832,6 +3826,10 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ministation/library)
+"pt" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "pz" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3901,9 +3899,14 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "qn" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/space,
-/area/ministation/science)
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = null;
+	name = "_South APC";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/ministation/maint/l3se)
 "qt" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3961,6 +3964,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3nw)
+"rc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/double/glass/science,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "rf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
@@ -4059,14 +4067,13 @@
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
 "rE" = (
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "conpipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "rI" = (
 /obj/machinery/recharge_station,
@@ -4436,9 +4443,8 @@
 /turf/simulated/floor/plating,
 /area/ministation/bridge)
 "tT" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 8;
-	set_temperature = 263
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -4744,14 +4750,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -4778,6 +4784,13 @@
 /obj/random_multi/single_item/matriarch_helmet,
 /turf/space,
 /area/space)
+"vE" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "vF" = (
 /obj/structure/table,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -4816,6 +4829,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3sw)
+"vK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/ministation/maint/l3se)
+"vL" = (
+/obj/machinery/button/mass_driver{
+	id_tag = "toxinsdriver";
+	pixel_y = 24
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "vM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4839,6 +4873,18 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
+"vX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -4872,7 +4918,7 @@
 /area/ministation/hall/s3)
 "wf" = (
 /obj/structure/stairs/long/east,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor,
 /area/ministation/science)
 "wg" = (
 /obj/structure/table/bench/wooden,
@@ -4904,6 +4950,12 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
+"wr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small/red,
+/obj/random/maintenance/research,
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "wv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
@@ -5099,6 +5151,16 @@
 /obj/structure/boulder,
 /turf/simulated/floor/grass,
 /area/ministation/science)
+"xX" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 8;
+	set_temperature = 263
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "ya" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5249,6 +5311,11 @@
 	},
 /turf/simulated/floor,
 /area/ministation/science)
+"yN" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "yP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5282,6 +5349,16 @@
 	floor_type = /turf/simulated/floor/tiled/stone
 	},
 /area/ministation/enclave/atrium)
+"yZ" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
+"zc" = (
+/obj/structure/table/gamblingtable,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "zd" = (
 /obj/machinery/camera/network/research{
 	dir = 4;
@@ -5529,6 +5606,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Av" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "Ax" = (
 /turf/simulated/floor/bluegrid{
 	name = "Mainframe Base";
@@ -5674,11 +5758,12 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Bb" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/doppler_array,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "Be" = (
 /obj/machinery/light/small{
@@ -5947,9 +6032,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Cs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
@@ -6402,16 +6484,11 @@
 /turf/simulated/floor/carpet/green,
 /area/ministation/library)
 "DS" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/gamblingtable,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "DX" = (
 /obj/machinery/network/relay{
@@ -6524,7 +6601,6 @@
 	},
 /obj/machinery/door/airlock/glass/science{
 	name = "Science Department";
-	req_access = list("ACCESS_ROBOTICS");
 	autoset_access = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6777,6 +6853,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "Gt" = (
@@ -6859,9 +6938,12 @@
 /turf/space,
 /area/space)
 "GT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	areastring = null;
+	name = "_South APC";
+	pixel_y = -24
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/ministation/court)
 "GY" = (
@@ -6904,6 +6986,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Hu" = (
@@ -7252,7 +7337,7 @@
 /area/ministation/hall/n3)
 "Jr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
+	pixel_x = 5;
 	pixel_y = 30
 	},
 /obj/structure/closet/firecloset,
@@ -7383,6 +7468,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Kj" = (
@@ -7658,6 +7744,15 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
+"Ma" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "Mb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7759,6 +7854,15 @@
 /obj/item/folder,
 /turf/simulated/floor/carpet/red,
 /area/ministation/court)
+"Mu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "My" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8044,12 +8148,14 @@
 /area/ministation/science)
 "NN" = (
 /obj/structure/table,
-/obj/machinery/alarm{
-	pixel_y = -2;
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light,
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "NO" = (
@@ -8435,6 +8541,18 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
+"PG" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "PL" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "science_shuttle_pump";
@@ -8529,7 +8647,7 @@
 /area/ministation/science)
 "Qf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -8543,16 +8661,8 @@
 /turf/simulated/floor/wood/yew,
 /area/ministation/court)
 "Qk" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3se)
@@ -8597,14 +8707,17 @@
 /area/ministation/hall/n3)
 "Qx" = (
 /obj/structure/table,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -25
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/item/storage/firstaid/stab,
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "Qz" = (
@@ -8621,8 +8734,15 @@
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
 "QF" = (
-/turf/simulated/wall,
-/area/space)
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "conpipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "QG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -8973,6 +9093,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"Ss" = (
+/obj/structure/flora/pottedplant/floorleaf,
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "Su" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -8988,6 +9116,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -9161,6 +9292,9 @@
 /obj/machinery/camera/network/research{
 	req_access = list("ACCESS_CAMERAS")
 	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "TC" = (
@@ -9168,10 +9302,8 @@
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
 "TD" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/wallframe_spawn/reinforced/polarized,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "TE" = (
 /obj/structure/cable{
@@ -9241,6 +9373,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "TR" = (
@@ -9312,6 +9447,14 @@
 /obj/machinery/faxmachine/mapped,
 /turf/simulated/floor/carpet/green,
 /area/ministation/yinglet_rep)
+"Uf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "Ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9387,6 +9530,9 @@
 "Uo" = (
 /obj/item/radio/intercom{
 	pixel_y = 31
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -9572,10 +9718,15 @@
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
 "Vp" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera/network/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Vq" = (
@@ -9589,6 +9740,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Vt" = (
+/obj/effect/decal/cleanable/blood/oil,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -9663,6 +9815,16 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/plating,
 /area/ministation/shuttle/outgoing)
+"VC" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/scientist,
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/science,
+/obj/item/clothing/suit/storage/toggle/wintercoat/yinglet/robotics,
+/obj/item/clothing/shoes/sandal/yinglet,
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "VI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9828,6 +9990,8 @@
 	name = "Xenobiology"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Wx" = (
@@ -10260,6 +10424,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
 "YO" = (
@@ -10371,9 +10538,6 @@
 	pixel_y = -24;
 	pixel_x = -5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/button/mass_driver{
 	pixel_y = -22;
 	pixel_x = 7;
@@ -10404,6 +10568,15 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
+"Zn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -10515,6 +10688,13 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/ministation/science)
+"ZL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/ministation/science)
 "ZO" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
@@ -10541,10 +10721,6 @@
 /obj/machinery/camera/network/research{
 	dir = 4;
 	req_access = list("ACCESS_CAMERAS")
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -23
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -45705,8 +45881,8 @@ od
 oC
 ae
 Qk
-ap
-ap
+vK
+qn
 oc
 aa
 aa
@@ -45907,8 +46083,8 @@ aa
 nl
 nl
 nQ
-ET
-VJ
+Vt
+GT
 Rx
 MA
 YQ
@@ -45939,11 +46115,11 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
 ae
+hm
+hN
+io
+iR
 ob
 As
 ae
@@ -45961,7 +46137,7 @@ nv
 oD
 oD
 ae
-iG
+ap
 ap
 DZ
 oc
@@ -46196,11 +46372,11 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
 ae
+hn
+hO
+iS
+iT
 ob
 As
 ae
@@ -46218,7 +46394,7 @@ nw
 oe
 mJ
 ae
-jd
+ap
 ap
 ap
 oc
@@ -46421,7 +46597,7 @@ aa
 aa
 aa
 nl
-Vt
+yz
 yH
 tZ
 Nw
@@ -46453,12 +46629,12 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
 ae
-ob
+hM
+ip
+QP
+BC
+Zn
 As
 ae
 hL
@@ -46679,7 +46855,7 @@ aa
 aa
 nl
 iq
-GT
+Tc
 Rx
 SW
 et
@@ -46710,12 +46886,12 @@ cw
 cw
 cw
 cw
-cw
 ae
 ae
 ae
 ae
-ob
+xX
+Ma
 yg
 ae
 ae
@@ -46967,18 +47143,18 @@ cw
 cw
 cw
 cw
-cw
 ae
 Mr
 GY
 ae
-ob
+jd
+Ma
 As
 ae
-hm
-hN
-io
-iR
+pt
+cZ
+DS
+Ss
 ZT
 kz
 NM
@@ -47232,10 +47408,10 @@ ae
 Er
 Zm
 ae
-hn
-hO
-iS
-iT
+ek
+db
+zc
+db
 db
 db
 NM
@@ -47489,10 +47665,10 @@ NB
 ob
 As
 ae
-hM
-ip
-QP
-BC
+yN
+cZ
+cZ
+tT
 jx
 Xa
 My
@@ -47749,7 +47925,7 @@ ae
 ae
 ae
 ae
-tT
+ae
 fc
 XS
 ob
@@ -47997,17 +48173,17 @@ NZ
 NZ
 NZ
 NZ
-ae
+dz
 Jr
 XS
 vw
 Xd
 Vs
 db
-ZO
+rc
 db
-db
-db
+TO
+yZ
 XS
 ob
 jM
@@ -48255,7 +48431,7 @@ dc
 ke
 rj
 dz
-UH
+VC
 Dd
 oP
 lM
@@ -50578,9 +50754,9 @@ Fm
 Fm
 wo
 dz
-Dd
+vX
 SA
-db
+tT
 ae
 ae
 cL
@@ -50818,7 +50994,7 @@ ar
 ar
 ar
 ae
-db
+UH
 em
 Dl
 qk
@@ -50835,11 +51011,11 @@ cb
 TG
 qJ
 dz
-ae
+RA
 cQ
-ae
-ae
-QF
+RA
+dz
+aa
 aa
 aa
 ei
@@ -51092,11 +51268,11 @@ Kj
 Kj
 gk
 dz
-ex
+TD
 eq
 TD
-mV
-QF
+dz
+aa
 aa
 aa
 nG
@@ -51340,7 +51516,7 @@ vj
 ae
 Uo
 Kh
-db
+ns
 WK
 dz
 cw
@@ -51349,11 +51525,11 @@ EV
 Zq
 Za
 dz
-DS
+oA
 rE
-Bb
-cZ
-ek
+wr
+dz
+aa
 aa
 aa
 nG
@@ -51589,13 +51765,13 @@ ae
 ae
 ae
 ae
-Vp
+An
 em
 db
 db
-As
+Vp
 Wv
-db
+ZL
 Qf
 db
 Zd
@@ -51606,12 +51782,12 @@ EV
 WV
 EV
 dz
-cL
-Ul
-cL
-ae
-ek
-ad
+TD
+eq
+TD
+dz
+dz
+aa
 aa
 nG
 RS
@@ -51844,7 +52020,7 @@ ae
 ae
 ae
 nm
-LC
+Uf
 LC
 eT
 Ht
@@ -51863,12 +52039,12 @@ Zq
 Dm
 sL
 dz
-JN
-ez
-JN
-qn
-ad
-ad
+vL
+Mu
+iL
+Bb
+dz
+aa
 aa
 nG
 nG
@@ -52105,7 +52281,7 @@ HQ
 sU
 Lp
 kS
-dx
+dd
 Cs
 vu
 ae
@@ -52120,12 +52296,12 @@ dz
 dz
 dz
 dz
-qn
-xT
-qn
+PG
+QF
+ex
+Av
+mV
 aa
-aa
-ad
 aa
 nG
 Qx
@@ -52357,7 +52533,7 @@ db
 Sn
 db
 db
-db
+vE
 db
 ae
 Vk
@@ -52377,11 +52553,11 @@ dz
 dz
 dz
 dz
-cw
-aa
-aa
-aa
-aa
+cL
+Ul
+cL
+dz
+mV
 ad
 aa
 ei
@@ -52633,12 +52809,12 @@ cw
 cw
 cw
 cw
-cw
-cw
-aa
-aa
-aa
-aa
+JN
+JN
+ez
+JN
+JN
+ad
 ad
 aa
 ei
@@ -52889,13 +53065,13 @@ cw
 cw
 cw
 ad
-ad
-ad
 aa
 aa
+JN
+xT
+JN
 aa
-ad
-ad
+aa
 ad
 aa
 aa
@@ -53147,11 +53323,11 @@ cw
 cw
 ad
 aa
-ad
 aa
 aa
 aa
-ad
+aa
+aa
 aa
 ad
 aa
@@ -53404,13 +53580,13 @@ cw
 cw
 ad
 aa
-ad
+aa
+aa
+aa
 aa
 aa
 aa
 ad
-aa
-UM
 aa
 aa
 aa
@@ -53660,14 +53836,14 @@ cw
 cw
 cw
 ad
-aa
+ad
 ad
 aa
 aa
 aa
 ad
-aa
-UM
+ad
+ad
 aa
 aa
 aa
@@ -53924,7 +54100,7 @@ aa
 aa
 ad
 aa
-UM
+ad
 aa
 aa
 aa
@@ -58806,7 +58982,7 @@ aa
 aa
 aa
 ad
-TX
+aa
 UM
 aa
 aa
@@ -59064,7 +59240,7 @@ aa
 aa
 ad
 aa
-ad
+UM
 aa
 aa
 aa
@@ -59321,7 +59497,7 @@ aa
 aa
 ad
 aa
-ad
+UM
 aa
 aa
 aa
@@ -59577,8 +59753,8 @@ aa
 aa
 aa
 ad
-aa
-ad
+TX
+UM
 aa
 aa
 aa
@@ -59829,6 +60005,777 @@ aa
 aa
 ad
 aa
+ad
+aa
+aa
+aa
+ad
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(193,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+aa
+aa
+aa
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(194,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+ad
+aa
+aa
+aa
+ad
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(195,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
 qU
 fF
 OF
@@ -59925,7 +60872,7 @@ aa
 aa
 aa
 "}
-(193,1,1) = {"
+(196,1,1) = {"
 aa
 aa
 aa
@@ -60182,7 +61129,7 @@ aa
 aa
 aa
 "}
-(194,1,1) = {"
+(197,1,1) = {"
 aa
 aa
 aa
@@ -60439,70 +61386,7 @@ aa
 aa
 aa
 "}
-(195,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+(198,1,1) = {"
 aa
 aa
 aa
@@ -60558,6 +61442,69 @@ aa
 aa
 aa
 ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -60696,7 +61643,7 @@ aa
 aa
 aa
 "}
-(196,1,1) = {"
+(199,1,1) = {"
 aa
 aa
 aa
@@ -60953,7 +61900,7 @@ aa
 aa
 aa
 "}
-(197,1,1) = {"
+(200,1,1) = {"
 aa
 aa
 aa
@@ -61210,777 +62157,6 @@ aa
 aa
 aa
 "}
-(198,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-Xm
-Bo
-Hw
-OF
-Hw
-Bo
-Pq
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(199,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-fF
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
-(200,1,1) = {"
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-"}
 (201,1,1) = {"
 aa
 aa
@@ -62141,13 +62317,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xm
+Bo
+Hw
+OF
+Hw
+Bo
+Pq
 aa
 aa
 aa
@@ -62401,7 +62577,7 @@ aa
 aa
 aa
 aa
-aa
+fF
 aa
 aa
 aa

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -2257,8 +2257,14 @@
 "iN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "_East APC";
+	pixel_x = 27;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
@@ -2427,17 +2433,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "_North APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2446,6 +2441,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3central)
@@ -2487,6 +2485,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/ministation/cargo/f3)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n3)
 "jL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2545,11 +2550,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/watertank/firefighter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "jU" = (
@@ -3496,21 +3500,12 @@
 /turf/simulated/wall/titanium,
 /area/ministation/shuttle/outgoing)
 "nI" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "_East APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/alarm{
 	pixel_y = -24;
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/ministation/hall/s3)
+/area/ministation/maint/l3central)
 "nL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/network/relay{
@@ -3841,7 +3836,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
-/area/ministation/hall/n3)
+/area/ministation/maint/l3central)
 "pB" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube{
@@ -3964,11 +3959,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3nw)
-"rc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/double/glass/science,
-/turf/simulated/floor/tiled/white,
-/area/ministation/science)
 "rf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
@@ -4154,7 +4144,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/ministation/library)
 "sp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4925,12 +4915,9 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "wk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "wl" = (
@@ -5514,9 +5501,8 @@
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3sw)
 "zW" = (
+/obj/machinery/door/airlock/double/glass/science,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "Aa" = (
@@ -6464,11 +6450,11 @@
 /turf/simulated/floor/tiled,
 /area/ministation/court)
 "DI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
@@ -6728,6 +6714,16 @@
 	pixel_x = 27
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n3)
+"Ft" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "_West APC";
+	pixel_x = -25
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "Fv" = (
@@ -8378,6 +8374,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "OW" = (
@@ -8835,7 +8834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
 "Ri" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8852,14 +8851,11 @@
 /turf/simulated/floor/grass,
 /area/ministation/science)
 "Rp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/ministation/maint/l3central)
+/turf/simulated/floor/tiled,
+/area/ministation/hall/n3)
 "Rt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8951,6 +8947,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
+"RH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/hall/s3)
 "RI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -9850,13 +9855,12 @@
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
 "VN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/item/stool,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "VW" = (
 /obj/machinery/light{
@@ -10405,20 +10409,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/yew,
 /area/ministation/court)
-"YJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/door/airlock/glass/science{
-	name = "Toxins";
-	req_access = list("ACCESS_XENOBIO");
-	autoset_access = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/ministation/science)
 "YL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -41745,7 +41735,7 @@ Yv
 Yv
 Yv
 Yv
-Rp
+Yv
 Bh
 ls
 Cd
@@ -42504,8 +42494,8 @@ ak
 OW
 tw
 OU
-OW
-OW
+jJ
+Ft
 Qu
 OW
 LI
@@ -43033,7 +43023,7 @@ Gy
 oN
 tt
 uS
-Pg
+RH
 Pg
 Pg
 Pg
@@ -43290,7 +43280,7 @@ Gy
 tt
 tt
 tt
-tt
+Mn
 tt
 tt
 tt
@@ -43546,9 +43536,9 @@ lb
 eZ
 MB
 fJ
+fJ
 iN
-iN
-iN
+fJ
 QG
 fJ
 zy
@@ -47667,7 +47657,7 @@ As
 ae
 yN
 cZ
-cZ
+VN
 tT
 jx
 Xa
@@ -48180,8 +48170,8 @@ vw
 Xd
 Vs
 db
-rc
 db
+zW
 TO
 yZ
 XS
@@ -48437,7 +48427,7 @@ oP
 lM
 sU
 HQ
-zW
+HQ
 wk
 HQ
 HQ
@@ -48695,8 +48685,8 @@ dz
 dz
 dz
 fS
-YJ
-VN
+dz
+dz
 dz
 it
 IP
@@ -50472,13 +50462,13 @@ cw
 cw
 cw
 sD
+Rp
+Rp
+Rp
 sC
-sC
-sC
-sC
-sC
-sC
-sC
+Rp
+Rp
+Rp
 sD
 db
 em

--- a/maps/ministation/ministation-3.dmm
+++ b/maps/ministation/ministation-3.dmm
@@ -1766,7 +1766,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/turf/space,
+/turf/simulated/floor/plating,
 /area/ministation/maint/l4central)
 "QM" = (
 /obj/effect/wingrille_spawn/reinforced_borosilicate/full,


### PR DESCRIPTION
## Description of changes
moved science server room
added lunch area to science
	opened up access to science lobby, added doorway blocking access to rest of science
added handbars to sides of shuttle cockpit (previously if you climbed on the table in the cockpit, there was no way to buckle in, and if someone was in the seat you couldnt leave so you took damage on landing)
added laser charger to shuttle
added ominous vault door leading to mass driver
	shifted mass driver and bomb range 3 tiles to the east
fixed missing oxygen piping to xenoarchaology
fixed misplaced light in maint north of dorms
changed tile to blank floor under stairway to bomb range stairwell, to mitigate popin
moved science apc into science lobby
rearranged items in the captains quarters for ease of use
rearranged items on medbay tables for ease of use
moved several APCs out of maints into the proper areas

## Why and what will this PR improve
Mostly minor tweaks for playability and cleaning up mistakes with the map
Particular focus given to improving access to, and usage of, the shuttle
Gordon Freeman can now destroy the research depts. lunch


## Changelog
:cl:
add: lunch area in science
add: in shuttle cockpit
add: laser charger in shuttle
add: small hallway leading to mass driver
tweak: moved science server room next to head of science's quarters
tweak: opened up access to science lobby, added doorway blocking access to rest of science
tweak: shifted mass driver and bomb range 3 tiles to the east to fit hallway
tweak: changed tile to blank floor under stairway to bomb range stairwell, to mitigate popin
tweak: moved science apc into science lobby
tweak: rearranged items in the captains quarters for ease of use
tweak: rearranged items on medbay tables for ease of use
tweak: moved several apcs into their areas proper
bugfix: fixed missing oxygen piping to xenoarchaology (not technically a bug, a mapping error)
bugfix: fixed misplaced light in maint north of dorms
/:cl: