### PR TITLE
Fixes to airlocks on colony/crashed pod

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -10,6 +10,12 @@
 	dir = 1;
 	name = "exterior access button"
 	},
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_x = -1;
+	id_tag = "crashed_pod_ext_sensor";
+	pixel_y = -19
+	},
 /turf/simulated/floor/plating,
 /area/map_template/crashed_pod)
 "ab" = (
@@ -905,7 +911,9 @@
 	pixel_x = -20;
 	tag_pump_out_external = "crashed_pod_pump_out_external";
 	tag_pump_out_internal = "crashed_pod_pump_out_internal";
-	cycle_to_external_air = 1
+	cycle_to_external_air = 1;
+	tag_exterior_sensor = "crashed_pod_ext_sensor";
+	tag_interior_sensor = "crashed_pod_int_sensor"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
@@ -1297,6 +1305,11 @@
 "DM" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -15;
+	id_tag = "crashed_pod_int_sensor"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "GT" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -6027,7 +6027,9 @@
 	tag_exterior_door = "playablecolonymain_exterior_door";
 	tag_exterior_sensor = "playablecolonymain_sensor_external";
 	tag_interior_door = "playablecolonymain_interior_door";
-	tag_interior_sensor = "playablecolonymain_sensor_interior"
+	tag_interior_sensor = "playablecolonymain_sensor_interior";
+	tag_pump_out_internal = "playablecolonymain_pump_out_internal";
+	tag_pump_out_external = "playablecolonymain_pump_out_external"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "playablecolonymain_pump";


### PR DESCRIPTION
fixed some ID issues on exterior colony airlock vents. Added sensors to crashed pod to help it cycle appropriately/add to the experience/thoroughness' sake.