### PR TITLE
Final meaningful Enclave update (for now!); some tweaks to Yingksy installations

### DIFF
--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -5468,7 +5468,8 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock{
-	pixel_x = 1
+	pixel_x = 1;
+	start_pressure = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -14362,10 +14363,7 @@
 	pixel_y = -23;
 	dir = 4
 	},
-/obj/machinery/atmospherics/binary/pump/on{
-	target_pressure = 200;
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/ministation/enclave/evacloset)
 "QF" = (

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -2469,7 +2469,9 @@
 /turf/space,
 /area/space)
 "hh" = (
-/mob/living/simple_animal/hostile/giant_spider/hunter,
+/mob/living/simple_animal/hostile/giant_spider/hunter{
+	name = "Timmy"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/atmospump)
 "hj" = (
@@ -3280,7 +3282,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ministation/engine)
 "jL" = (
-/obj/item/pen,
+/obj/item/pen{
+	name = "Gikka's Lost Pen";
+	pen_font = "Times New Roman";
+	desc = "Not to be confused with Gikka's Pen."
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
 "jM" = (
@@ -3926,6 +3932,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/transit_tube_pod{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ministation/enclave/evacloset)
 "lK" = (
@@ -4127,6 +4136,15 @@
 /obj/structure/tank_rack/oxygen,
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
+"mm" = (
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4;
+	name = "Gikka's Pen";
+	desc = "Oh! Found it!"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ministation/ai_upload)
 "mo" = (
 /obj/machinery/light{
 	dir = 1
@@ -5449,7 +5467,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	pixel_x = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -7580,6 +7600,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n)
+"xs" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/gatehouse)
 "xt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -8560,7 +8589,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	id_tag = "enclave_vent"
 	},
 /obj/item/trash/mollusc_shell/barnacle{
@@ -11316,9 +11345,7 @@
 /obj/structure/transit_tube/station{
 	dir = 4
 	},
-/obj/structure/transit_tube_pod{
-	dir = 1
-	},
+/obj/structure/transit_tube_pod,
 /turf/simulated/floor,
 /area/ministation/enclave/scikitchen)
 "HN" = (
@@ -11837,10 +11864,6 @@
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ministation/ai_upload)
@@ -12833,7 +12856,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/ministation/engine)
 "LX" = (
-/mob/living/simple_animal/hostile/giant_spider/guard,
+/mob/living/simple_animal/hostile/giant_spider/guard{
+	name = "Jimmy"
+	},
 /turf/simulated/floor/plating,
 /area/ministation/atmospump)
 "LY" = (
@@ -14157,7 +14182,11 @@
 	color = "#000099";
 	desc = "...You feel like you've met this one before.";
 	name = "blue meatball";
-	nutriment_type = list(/decl/material/liquid/nutriment = 10, /decl/material/liquid/amphetamines = 30, /decl/material/liquid/zombie = 10, /decl/material/liquid/psychoactives = 25, /decl/material/liquid/hallucinogenics = 25)
+	nutriment_type = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	nutriment_desc = list("hell" = 1);
+	germ_level = 9001;
+	material = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	matter = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25)
 	},
 /turf/space,
 /area/space)
@@ -14333,7 +14362,10 @@
 	pixel_y = -23;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/binary/pump/on{
+	target_pressure = 200;
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ministation/enclave/evacloset)
 "QF" = (
@@ -14623,7 +14655,8 @@
 	dir = 4;
 	name = "Bast Fastard";
 	desc = "A reliable piece of trash that's gotten the mining crew out of more scrapes than is deemed reasonable by OSHA.";
-	max_health = 500
+	max_health = 500;
+	color = "#ff9494"
 	},
 /turf/simulated/floor/airless,
 /area/ministation/mining)
@@ -14860,6 +14893,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/eva)
+"Sd" = (
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/gatehouse)
 "Se" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15920,6 +15956,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/trash)
+"VN" = (
+/obj/structure/stairs/long/catwalk/north,
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/gatehouse)
 "VO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16590,6 +16630,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/structure/transit_tube_pod{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ministation/enclave/entrance)
 "Yr" = (
@@ -16664,7 +16707,8 @@
 /obj/vehicle/bike/gyroscooter{
 	dir = 8;
 	name = "Impossible Dreams, by Yingksy";
-	desc = "It's not worth it, dude."
+	desc = "It's not worth it, dude.";
+	color = "#ffbd00"
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/ministation/atmospherics)
@@ -16828,9 +16872,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
 	},
 /obj/item/trash/mollusc_shell/clam{
 	pixel_x = -10;
@@ -44446,7 +44487,7 @@ aa
 aa
 ab
 aa
-aa
+iH
 PM
 As
 mG
@@ -44701,10 +44742,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 iH
+iH
+iH
+xs
 Zc
 Na
 kR
@@ -44958,10 +44999,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
 iH
+VN
+Sd
+Sd
 iH
 iH
 iH
@@ -45215,11 +45256,11 @@ aa
 af
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+iH
+iH
+iH
+iH
+iH
 aa
 ad
 ad
@@ -64862,7 +64903,7 @@ jx
 JN
 Jo
 JD
-JD
+mm
 JD
 Kr
 JN

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -3351,7 +3351,6 @@
 	dir = 4
 	},
 /obj/structure/table/bench/padded,
-/obj/structure/emergency_dispenser/west,
 /turf/simulated/floor/tiled/stone,
 /area/ministation/enclave/messhall)
 "kx" = (
@@ -10203,7 +10202,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/emergency_dispenser/west,
 /turf/simulated/floor/shuttle_ceiling/air,
 /area/ministation/enclave/airroom)
 "Es" = (

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -315,6 +315,9 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/ministation/detective)
+"aY" = (
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "ba" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube{
@@ -501,6 +504,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/toy/figure/clown{
+	name = "Suspiciously blood-red toy clown, by Yingksy";
+	germ_level = 9001;
+	color = "#600000";
+	desc = "Oh goods."
+	},
 /turf/simulated/floor/carpet/blue,
 /area/ministation/medical)
 "bI" = (
@@ -639,6 +648,10 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ministation/security)
+"cb" = (
+/obj/machinery/light,
+/turf/open,
+/area/ministation/enclave/tower)
 "cc" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -1284,6 +1297,7 @@
 	pixel_x = -22;
 	pixel_y = -7
 	},
+/obj/structure/transit_tube_pod,
 /turf/simulated/floor,
 /area/ministation/enclave/armory)
 "ef" = (
@@ -1943,6 +1957,9 @@
 	},
 /turf/simulated/floor/tiled/stone,
 /area/ministation/enclave/matriarch)
+"gr" = (
+/turf/space,
+/area/ministation/enclave/tower)
 "gu" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SE"
@@ -2242,7 +2259,7 @@
 	dir = 4
 	},
 /obj/item/toy/plushie/carp/silent{
-	name = "Spookums the Teleporting Trout";
+	name = "Spookums the Teleporting Trout, by Yingksy";
 	desc = "Who put this here!?"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2971,8 +2988,11 @@
 /turf/simulated/floor/plating,
 /area/ministation/enclave/engineering)
 "jn" = (
-/turf/simulated/wall,
-/area/ministation/enclave/atrium)
+/obj/machinery/atmospherics/unary/tank/hydrogen{
+	anchored = 0
+	},
+/turf/simulated/floor/shuttle_ceiling/air,
+/area/ministation/enclave/airroom)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3093,6 +3113,7 @@
 /area/ministation/enclave/tower)
 "jJ" = (
 /obj/structure/lattice,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
 /area/ministation/enclave/matriarch)
 "jM" = (
@@ -3519,7 +3540,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id_tag = "matblast";
-	name = "mat blast door";
+	name = "matriarchal blast door";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -4471,6 +4492,10 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/ministation/maint/hydromaint)
+"om" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/ministation/enclave/airroom)
 "on" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -6480,6 +6505,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/e2)
+"tF" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ministation/enclave/tower)
 "tG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -7402,7 +7432,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled,
 /area/ministation/enclave/tower)
 "wj" = (
 /obj/effect/shuttle_landmark/arrivas_south{
@@ -9277,6 +9307,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/transit_tube_pod{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/ministation/enclave/matriarch)
 "Bj" = (
@@ -9585,6 +9618,10 @@
 "Ck" = (
 /turf/simulated/floor/plating,
 /area/ministation/maint/l2underpass)
+"Cl" = (
+/obj/structure/stairs/long/catwalk,
+/turf/space,
+/area/ministation/enclave/tower)
 "Co" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9742,6 +9779,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ministation/cryo)
+"CR" = (
+/turf/open,
+/area/ministation/enclave/tower)
 "CU" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock";
@@ -10145,8 +10185,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/blast/regular/open{
 	id_tag = "matblast";
-	name = "mat blast door";
-	dir = 2
+	name = "matriarchal blast door"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ministation/enclave/matriarch)
@@ -11499,11 +11538,32 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
+/obj/item/toy/figure/clown{
+	name = "Suspiciously blood-red toy clown, by Yingksy";
+	germ_level = 9001;
+	color = "#600000";
+	desc = "Oh good."
+	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/surgicals)
 "Jd" = (
 /turf/simulated/wall/r_wall,
 /area/ministation/securityoffice)
+"Jf" = (
+/obj/structure/lattice,
+/obj/item/chems/food/meatball{
+	filling_color = "#000099";
+	color = "#000099";
+	desc = "...You feel like you've met this one before.";
+	name = "blue meatball";
+	nutriment_type = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	nutriment_desc = list("hell" = 1);
+	germ_level = 9001;
+	material = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	matter = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25)
+	},
+/turf/space,
+/area/space)
 "Ji" = (
 /turf/simulated/floor/grass,
 /area/ministation/hydro)
@@ -11741,9 +11801,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/ministation/medical/nursery)
 "JM" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/ministation/enclave/atrium)
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/ministation/enclave/armory)
 "JO" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/storage/box/ammo/stunshells/large,
@@ -13992,6 +14053,13 @@
 	},
 /turf/simulated/wall/brick,
 /area/ministation/enclave/matriarch)
+"Rt" = (
+/obj/structure/railing/mapped{
+	icon_state = "railing0-0";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "Ru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -14141,7 +14209,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/wall,
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled,
 /area/ministation/enclave/tower)
 "RT" = (
 /obj/machinery/door/airlock/glass/security{
@@ -14544,7 +14613,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/ministation/enclave/atrium)
+/area/ministation/enclave/airroom)
 "SZ" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical/emt,
@@ -38368,7 +38437,7 @@ vs
 vs
 vs
 vs
-jn
+ea
 Gw
 Gw
 Gw
@@ -38625,12 +38694,12 @@ JI
 cX
 cX
 cX
-JM
+tw
 yo
 Nw
 Nw
 JC
-JC
+jn
 Gw
 ru
 ad
@@ -38882,7 +38951,7 @@ qj
 nd
 zc
 nP
-jn
+ea
 LP
 KA
 By
@@ -39139,7 +39208,7 @@ TE
 nA
 UU
 lr
-jn
+ea
 uo
 tw
 ea
@@ -39653,7 +39722,7 @@ Os
 Uq
 Uq
 qb
-GU
+om
 Rn
 GM
 tw
@@ -39910,9 +39979,9 @@ nq
 bS
 bS
 UK
-nO
-Sz
-Sz
+ea
+tw
+tw
 ea
 Gw
 Gw
@@ -40426,7 +40495,7 @@ Yi
 lf
 Bh
 Qn
-as
+JM
 nH
 eJ
 rA
@@ -40683,7 +40752,7 @@ RY
 HZ
 Bh
 FY
-as
+JM
 UD
 sE
 eM
@@ -41449,7 +41518,7 @@ aa
 aa
 ad
 ad
-ad
+Jf
 aa
 YL
 YN
@@ -43758,10 +43827,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Uk
+tF
+tF
+tF
 Jv
 kx
 Ek
@@ -44015,10 +44084,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+tF
+aY
+Rt
+Rt
 RS
 wg
 KO
@@ -44272,13 +44341,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-HO
-HO
-HO
+tF
+aY
+gr
+Cl
+Uk
+Uk
+Uk
 HO
 HO
 aa
@@ -44529,11 +44598,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-HO
+tF
+aY
+CR
+cb
+Uk
 HO
 HO
 HO
@@ -44786,12 +44855,12 @@ aa
 af
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+Uk
+tF
+tF
+tF
+Uk
+HO
 aa
 aa
 aa

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -88,7 +88,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "ax" = (
 /obj/structure/cable{
@@ -1045,7 +1049,7 @@
 /area/ministation/maint/l3ne)
 "du" = (
 /mob/living/slime,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "dv" = (
 /obj/machinery/cryopod/robot,
@@ -1079,7 +1083,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "dE" = (
 /obj/structure/cable{
@@ -1137,6 +1141,12 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
@@ -1242,7 +1252,7 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "ei" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -1275,6 +1285,12 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ministation/bombrange)
+"ep" = (
+/obj/structure/bed/chair/armchair/black{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "eq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -1626,12 +1642,17 @@
 /obj/item/bedsheet/green{
 	pixel_y = 11
 	},
-/obj/item/hatchet/machete/deluxe,
-/obj/item/shield/buckler,
+/obj/item/hatchet/machete/deluxe{
+	desc = "Discovered in the hand of some dead guy outside the Matriarch's window.";
+	name = "Manstabber"
+	},
+/obj/item/shield/buckler{
+	desc = "An old clam-serving tray of sturdy, totally-reliable Yinglet make!";
+	name = "Clamplate"
+	},
 /obj/item/radio/intercom{
-	name = "Common Channel";
-	pixel_x = 1;
-	pixel_y = 23
+	pixel_y = 25;
+	pixel_x = 1
 	},
 /obj/item/toy/plushie/fox/purple{
 	pixel_y = 12;
@@ -1714,6 +1735,12 @@
 	dir = 9
 	},
 /obj/item/trash/mollusc_shell/barnacle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
 "fP" = (
@@ -1750,6 +1777,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"gb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "gd" = (
 /obj/machinery/destructive_analyzer{
 	initial_network_id = "molluscnet"
@@ -1805,7 +1838,9 @@
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
 "go" = (
-/mob/living/simple_animal/hostile/retaliate/goose,
+/mob/living/simple_animal/hostile/retaliate/goose{
+	move_speed = 20
+	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
 "gp" = (
@@ -1996,6 +2031,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"ha" = (
+/obj/structure/bed/chair/armchair/red{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "hc" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube{
@@ -2097,6 +2138,17 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ministation/library)
+"hw" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "hx" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
@@ -2285,6 +2337,16 @@
 /obj/structure/ladder,
 /turf/open,
 /area/ministation/maint/l3nw)
+"hZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/basic/full,
+/obj/structure/curtain/black,
+/obj/machinery/door/blast/regular/open{
+	id_tag = "conblast";
+	name = "diplomacy door"
+	},
+/turf/simulated/floor/plating,
+/area/ministation/enclave/conference)
 "if" = (
 /obj/machinery/door/window/eastright{
 	autoset_access = 0
@@ -2431,6 +2493,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
+"iD" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor2"
+	},
+/turf/simulated/wall,
+/area/ministation/science)
 "iG" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/stack/material/nullglass/fifty,
@@ -2667,10 +2735,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/item/trash/mollusc_shell/clam,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
 "jC" = (
@@ -3387,6 +3458,12 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/ministation/enclave/tower)
+"lR" = (
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "lT" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood/yew,
@@ -3685,6 +3762,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
+"nb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/wall/r_wall,
+/area/ministation/enclave/conference)
 "nc" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/flashlight/lamp/green{
@@ -3956,11 +4040,22 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	id_tag = "matblast";
-	name = "mat blast door";
+	name = "matriarchal blast door";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ministation/enclave/matriarch)
+"oo" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/basic/full,
+/obj/structure/curtain/black,
+/obj/machinery/door/blast/regular/open{
+	id_tag = "conblast";
+	name = "diplomacy door";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ministation/enclave/conference)
 "op" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4009,6 +4104,9 @@
 	dir = 8;
 	pixel_y = 16;
 	pixel_x = 9
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/stone,
 /area/ministation/enclave/atrium)
@@ -4074,6 +4172,73 @@
 	},
 /turf/simulated/floor/tiled/stone,
 /area/ministation/enclave/matriarch)
+"oM" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 9
+	},
+/mob/living/simple_animal/hostile/retaliate/clown{
+	color = "#600000";
+	name = "We, by Yingksy";
+	desc = "Oh gods.";
+	emote_see = list("screams incoherently");
+	emote_speech = list("HAaaAAAUGHNNK!!!","HAAWAAAWAUUGHHNNKKGG!!!", "hhhhHHHHAAAAUUUGGHHHNNNKK!!!!!", "hhhHHhhhhHAAAAUGGHHHGhhhAAAUUGHhhhHHAAAAUGHHHNnggnnkk!!!!!");
+	bleed_colour = "#000000";
+	move_speed = 1;
+	max_health = 9001;
+	minbodytemp = -666;
+	maxbodytemp = 666;
+	mob_size = 25;
+	death_message = "gurgles hideously and drops to the floor!";
+	break_stuff_probability = 50;
+	cold_damage_per_tick = 1;
+	emote_hear = list("cackles horrendously");
+	faction = "He";
+	friendly = "";
+	harm_intent_damage = 15;
+	heat_damage_per_tick = 1;
+	climb_speed_mult = 3;
+	hydration = 9001;
+	meat_amount = 20;
+	throw_range = 15;
+	throw_speed = 5;
+	speak_chance = 10;
+	see_invisible = 100;
+	see_infrared = 100;
+	see_in_dark = 100;
+	response_disarm = "";
+	response_harm = list("slashes", "shreds", "tears", "rips", "gores");
+	response_help_1p = "";
+	response_help_3p = "";
+	pry_desc = list("prying", "pushing", "ripping", "smashing");
+	pry_time = 45;
+	reagents = list(/decl/material/liquid/nutriment = 10, /decl/material/liquid/amphetamines = 30, /decl/material/liquid/zombie = 20, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	ranged_range = 12;
+	glowing_eyes = 1;
+	germ_level = 9001;
+	fire_desc = "";
+	can_pull_size = 60;
+	can_buckle = 1;
+	bone_amount = 10;
+	blood_type = "X";
+	unsuitable_atmos_damage = 1;
+	nutrition = 9001;
+	bodytemperature = 0;
+	speak_emote = list("screeches")
+	},
+/obj/item/chems/drinks/zombiedrink{
+	color = "#600000";
+	desc = "Oh no.";
+	name = "Clown-Shaped Vial";
+	germ_level = 9001
+	},
+/turf/exterior/mud{
+	color = "#600000";
+	desc = "Oh hell.";
+	name = "congealed gunk";
+	germ_level = 9001
+	},
+/area/ministation/science)
 "oN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
@@ -4139,18 +4304,6 @@
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
-	},
-/obj/structure/table/bench/padded{
-	pixel_y = 14;
-	pixel_x = 4
-	},
-/obj/item/clothing/head/kitty{
-	pixel_y = 11;
-	pixel_x = 4
-	},
-/obj/item/mollusc/clam{
-	pixel_y = 6;
-	pixel_x = -6
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/enclave/tower)
@@ -4295,6 +4448,20 @@
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
+"pR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#600000";
+	germ_level = 9001;
+	name = "suspiciously blood-red disposal pipe";
+	desc = "Oh crap."
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "pS" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -4398,6 +4565,20 @@
 /obj/effect/floor_decal/corner/green/full,
 /turf/simulated/floor/tiled/white,
 /area/ministation/biodome)
+"qF" = (
+/obj/abstract/landmark/mapped_fluid/fill{
+	fluid_type = /decl/material/liquid/zombie;
+	germ_level = 9001;
+	color = "#600000"
+	},
+/turf/exterior/mud/flooded{
+	flooded = /decl/material/liquid/zombie;
+	germ_level = 9001;
+	color = "#600000";
+	name = "putrid sludge";
+	desc = "Oh jeez."
+	},
+/area/ministation/science)
 "qJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -4412,6 +4593,10 @@
 	},
 /turf/space,
 /area/space)
+"qM" = (
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "qO" = (
 /obj/structure/bed/chair/wood/walnut{
 	dir = 4
@@ -4436,6 +4621,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3nw)
+"qZ" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
+"ra" = (
+/obj/abstract/landmark/mapped_fluid/fill{
+	fluid_type = /decl/material/liquid/psychoactives;
+	germ_level = 9001;
+	color = "#600000"
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 1
+	},
+/turf/exterior/mud/flooded{
+	flooded = /decl/material/liquid/psychoactives;
+	germ_level = 9001;
+	color = "#600000";
+	name = "congealed gunk";
+	desc = "Oh hell."
+	},
+/area/ministation/science)
 "rf" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -4587,6 +4796,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/biodome)
+"rU" = (
+/obj/structure/lattice,
+/turf/simulated/wall/r_wall,
+/area/ministation/enclave/conference)
 "rV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -4655,6 +4868,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/ministation/library)
+"so" = (
+/obj/machinery/light/small{
+	dir = 4;
+	color = "#600000";
+	flickering = 1;
+	name = "suspiciously blood-red light fixture";
+	desc = "Oh gosh.";
+	germ_level = 9001
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "sp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4698,6 +4926,19 @@
 /obj/structure/bookcase/skill_books/random,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"sz" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = 29
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "sB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4843,6 +5084,12 @@
 	},
 /turf/simulated/floor,
 /area/ministation/enclave/foyer)
+"tl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4958,6 +5205,9 @@
 	},
 /turf/simulated/wall,
 /area/ministation/hall/n3)
+"tG" = (
+/turf/open,
+/area/ministation/enclave/tower)
 "tJ" = (
 /obj/structure/hygiene/sink/kitchen{
 	dir = 8;
@@ -5053,6 +5303,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"um" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor5"
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	color = "#600000";
+	name = "suspiciously blood-red light fixture";
+	desc = "Oh gosh.";
+	germ_level = 9001
+	},
+/turf/exterior/mud{
+	color = "#600000";
+	desc = "Oh hell.";
+	name = "congealed gunk";
+	germ_level = 9001
+	},
+/area/ministation/science)
 "un" = (
 /obj/structure/bed/chair/wood/walnut{
 	dir = 1
@@ -5255,11 +5526,14 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 2
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ministation/enclave/atrium)
@@ -5453,6 +5727,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
+	},
+/obj/structure/transit_tube_pod{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/ministation/enclave/tower)
@@ -5685,6 +5962,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"wI" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "wJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	external_pressure_bound = 98;
@@ -5829,6 +6113,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/cargo/f3)
+"xp" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "xr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6035,6 +6326,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3central)
+"yr" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor3"
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
+/turf/exterior/mud{
+	color = "#600000";
+	desc = "Oh hell.";
+	name = "congealed gunk";
+	germ_level = 9001
+	},
+/area/ministation/science)
 "yt" = (
 /obj/machinery/vending/hydronutrients{
 	dir = 8
@@ -6116,10 +6421,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/blast/regular/open{
 	id_tag = "matblast";
-	name = "mat blast door"
+	name = "matriarchal blast door"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ministation/enclave/matriarch)
+"yF" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "yH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -6183,6 +6492,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
+"yV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
+"yW" = (
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "yY" = (
 /turf/simulated/wall/r_wall/hull,
 /area/ministation/enclave/atrium)
@@ -6335,6 +6653,11 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"zz" = (
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/item/storage/slide_projector,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "zC" = (
 /turf/simulated/floor/carpet/magenta,
 /area/ministation/science)
@@ -6589,15 +6912,12 @@
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
 "AP" = (
-/obj/effect/floor_decal/carpet/green{
-	dir = 8
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 4
 	},
-/mob/living/simple_animal/chick{
-	name = "Floofbirb";
-	desc = "He's so floofy!!"
-	},
-/turf/simulated/floor/carpet/green,
-/area/ministation/enclave/matriarch)
+/turf/simulated/wall,
+/area/ministation/science)
 "AQ" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 4
@@ -6826,6 +7146,12 @@
 	dir = 4
 	},
 /obj/random/trash,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
 "BC" = (
@@ -7035,10 +7361,10 @@
 	immunity = 0;
 	immunity_norm = 0;
 	holding_breath = 1;
-	damage_multiplier = 5;
+	damage_multiplier = 10;
 	bone_amount = 5;
 	a_intent = "harm";
-	color = "#5fffdd"
+	color = "#6878ff"
 	},
 /turf/open,
 /area/ministation/hall/n3)
@@ -7402,6 +7728,10 @@
 /obj/structure/disposalpipe/junction/mirrored,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
+"Dq" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Dt" = (
 /turf/simulated/wall,
 /area/ministation/maint/l3sw)
@@ -7566,6 +7896,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"DU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "DX" = (
 /obj/effect/floor_decal/corner/green/border{
 	dir = 9
@@ -7576,6 +7912,10 @@
 /obj/item/cash/scavbucks,
 /turf/simulated/floor/tiled/white,
 /area/ministation/maint/l3se)
+"Ea" = (
+/obj/machinery/door/airlock/hatch/maintenance,
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "Eb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -7658,6 +7998,24 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
+/area/ministation/science)
+"Es" = (
+/obj/abstract/landmark/mapped_fluid/fill{
+	fluid_type = /decl/material/liquid/hallucinogenics;
+	germ_level = 9001;
+	color = "#600000"
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 1
+	},
+/obj/structure/window/borosilicate_reinforced,
+/turf/exterior/mud/flooded{
+	flooded = /decl/material/liquid/hallucinogenics;
+	germ_level = 9001;
+	color = "#600000";
+	name = "congealed gunk";
+	desc = "Oh hell."
+	},
 /area/ministation/science)
 "Et" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7823,6 +8181,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/biodome)
+"EY" = (
+/obj/abstract/landmark/mapped_fluid/fill{
+	fluid_type = /decl/material/liquid/amphetamines;
+	germ_level = 9001;
+	color = "#600000"
+	},
+/obj/structure/window/borosilicate_reinforced,
+/turf/exterior/mud/flooded{
+	flooded = /decl/material/liquid/amphetamines;
+	germ_level = 9001;
+	color = "#600000";
+	name = "congealed gunk";
+	desc = "Oh hell."
+	},
+/area/ministation/science)
 "Fa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7889,6 +8262,27 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled,
 /area/ministation/hall/n3)
+"Fs" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8;
+	germ_level = 9001;
+	color = "#600000";
+	name = "suspiciously blood-red disposal pipe";
+	desc = "Oh crap."
+	},
+/obj/structure/disposaloutlet{
+	dir = 1;
+	color = "#600000";
+	germ_level = 9001;
+	desc = "Oh shit.";
+	name = "suspiciously blood-red disposal outlet"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "Ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable,
@@ -8203,6 +8597,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ministation/court)
+"GV" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor5"
+	},
+/turf/simulated/wall,
+/area/ministation/science)
 "GW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -8213,6 +8613,26 @@
 /obj/item/toy/figure/scientist,
 /turf/simulated/floor,
 /area/ministation/science)
+"GZ" = (
+/obj/machinery/button/blast_door{
+	id_tag = "conblast";
+	name = "Diplomacy Button";
+	pixel_y = 11;
+	pixel_x = -22
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light{
+	dir = 2
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Hb" = (
 /turf/simulated/wall,
 /area/ministation/biodome)
@@ -8331,7 +8751,7 @@
 	id_tag = "slimeblast2";
 	name = "enclosure 2 blast door"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "HQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8392,6 +8812,12 @@
 	dir = 1;
 	pixel_y = -27
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
 "Ia" = (
@@ -8440,6 +8866,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
+"Ii" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/regular/open{
+	id_tag = "conblast";
+	name = "diplomacy door"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ministation/enclave/conference)
 "Ik" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/plating,
@@ -8532,6 +8974,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Iy" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Iz" = (
 /obj/structure/lattice,
 /turf/exterior/wall/random/ministation,
@@ -8805,6 +9260,43 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/airless,
 /area/ministation/science)
+"JR" = (
+/mob/living/simple_animal/fowl/chicken{
+	name = "Floofbirb";
+	desc = "He's so floofy!!"
+	},
+/turf/simulated/floor/carpet/green,
+/area/ministation/enclave/matriarch)
+"JS" = (
+/obj/structure/table/bench/padded{
+	pixel_y = 14;
+	pixel_x = 4
+	},
+/obj/item/clothing/head/kitty{
+	pixel_y = 11;
+	pixel_x = 4
+	},
+/obj/item/mollusc/clam{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/mollusc/clam{
+	pixel_x = 1
+	},
+/obj/item/mollusc/clam{
+	pixel_y = 13;
+	pixel_x = 1
+	},
+/obj/item/mollusc/clam{
+	pixel_y = 17;
+	pixel_x = -6
+	},
+/obj/item/mollusc/clam{
+	pixel_x = 12;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "JV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8847,16 +9339,54 @@
 	name = "He, by Yingksy";
 	desc = "Oh god.";
 	emote_see = list("screams incoherently");
-	emote_speech = list("HAaaAAAUGHNNK!!!","HAAWAAAWAUUGHHNNKKGG!!!","hhhhHHHHAAAAUUUGGHHHNNNKK!!!!!");
+	emote_speech = list("HAaaAAAUGHNNK!!!","HAAWAAAWAUUGHHNNKKGG!!!", "hhhhHHHHAAAAUUUGGHHHNNNKK!!!!!", "hhhHHhhhhHAAAAUGGHHHGhhhAAAUUGHhhhHHAAAAUGHHHNnggnnkk!!!!!");
 	bleed_colour = "#000000";
 	move_speed = 1;
-	max_health = 5000;
-	minbodytemp = 0;
-	maxbodytemp = 1000;
+	max_health = 9001;
+	minbodytemp = -666;
+	maxbodytemp = 666;
 	mob_size = 25;
-	death_message = "gurgles hideously and drops to the floor!"
+	death_message = "gurgles hideously and drops to the floor!";
+	break_stuff_probability = 50;
+	cold_damage_per_tick = 1;
+	emote_hear = list("cackles horrendously");
+	faction = "He";
+	friendly = "";
+	harm_intent_damage = 15;
+	heat_damage_per_tick = 1;
+	climb_speed_mult = 3;
+	hydration = 9001;
+	meat_amount = 20;
+	throw_range = 15;
+	throw_speed = 5;
+	speak_chance = 10;
+	see_invisible = 100;
+	see_infrared = 100;
+	see_in_dark = 100;
+	response_disarm = "";
+	response_harm = list("slashes", "shreds", "tears", "rips", "gores");
+	response_help_1p = "";
+	response_help_3p = "";
+	pry_desc = list("prying", "pushing", "ripping", "smashing");
+	pry_time = 45;
+	reagents = list(/decl/material/liquid/nutriment = 10, /decl/material/liquid/amphetamines = 30, /decl/material/liquid/zombie = 20, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	ranged_range = 12;
+	glowing_eyes = 1;
+	germ_level = 9001;
+	fire_desc = "";
+	can_pull_size = 60;
+	can_buckle = 1;
+	bone_amount = 10;
+	blood_type = "X";
+	unsuitable_atmos_damage = 1;
+	nutrition = 9001;
+	bodytemperature = 0;
+	speak_emote = list("screeches")
 	},
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "Kf" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
@@ -8883,6 +9413,12 @@
 /obj/effect/wingrille_spawn/reinforced_borosilicate/full,
 /turf/simulated/floor/reinforced/airless,
 /area/ministation/science)
+"Kp" = (
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/catwalk,
+/obj/structure/lattice/wood,
+/turf/open,
+/area/ministation/enclave/conference)
 "Kq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -8929,6 +9465,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
+"Kx" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 2;
+	color = "#600000";
+	desc = "Oh gosh.";
+	name = "suspiciously blood-red light fixture";
+	germ_level = 9001
+	},
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
+/turf/exterior/mud{
+	color = "#600000";
+	desc = "Oh hell.";
+	name = "congealed gunk";
+	germ_level = 9001
+	},
+/area/ministation/science)
 "Ky" = (
 /obj/machinery/light{
 	dir = 1
@@ -8976,6 +9534,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
+"KH" = (
+/obj/machinery/hologram/holopad/longrange,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
+"KO" = (
+/obj/structure/lattice,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "KP" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
 /obj/machinery/vending/boozeomat,
@@ -9074,6 +9643,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Lt" = (
+/obj/structure/bed/chair/armchair/green{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Lu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -9468,6 +10043,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ministation/science)
+"MX" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "MY" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -9594,6 +10179,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/shuttle/outgoing)
+"Nv" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/window/borosilicate_reinforced{
+	dir = 4
+	},
+/turf/exterior/mud{
+	color = "#600000";
+	desc = "Oh hell.";
+	name = "congealed gunk";
+	germ_level = 9001
+	},
+/area/ministation/science)
 "Nw" = (
 /turf/simulated/floor/tiled,
 /area/ministation/court)
@@ -9651,8 +10248,14 @@
 "NL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ministation/enclave/atrium)
@@ -9766,6 +10369,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Oi" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/basic/full,
+/obj/machinery/door/blast/regular/open{
+	id_tag = "conblast";
+	name = "diplomacy door"
+	},
+/turf/simulated/floor/plating,
+/area/ministation/enclave/conference)
 "Ok" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -9996,6 +10608,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"Ph" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#600000";
+	germ_level = 9001;
+	name = "suspiciously blood-red disposal pipe";
+	desc = "Oh crap."
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "dir_splatter_2";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ministation/science)
 "Pi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10047,6 +10673,12 @@
 	},
 /turf/space,
 /area/space)
+"Pr" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "Pt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10137,6 +10769,12 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
+"PC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open,
+/area/ministation/enclave/tower)
 "PD" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/flashlight/lamp/green{
@@ -10602,12 +11240,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/window/eastleft,
+/obj/machinery/door/window/eastleft{
+	color = "#600000";
+	germ_level = 9001;
+	name = "suspiciously blood-red glass door";
+	desc = "Oh man."
+	},
 /obj/machinery/door/blast/regular/open{
 	id_tag = "slimeblast1";
 	name = "enclosure 1 blast door"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor,
 /area/ministation/science)
 "RE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -10778,7 +11422,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id_tag = "matblast";
-	name = "mat blast door";
+	name = "matriarchal blast door";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -10829,6 +11473,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"Sr" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/enclave/tower)
 "Ss" = (
 /obj/structure/flora/pottedplant/floorleaf,
 /obj/item/radio/intercom{
@@ -10887,6 +11537,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ministation/hall/s3)
+"SK" = (
+/turf/simulated/wall/r_wall/hull,
+/area/ministation/science)
 "SL" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 1
@@ -10969,6 +11622,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/maint/l3ne)
+"Td" = (
+/obj/structure/catwalk,
+/obj/structure/table/woodentable_reinforced/ebony/walnut,
+/obj/structure/lattice/wood,
+/turf/open,
+/area/ministation/enclave/conference)
 "Tk" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/mahogany,
@@ -11340,6 +11999,13 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/ministation/library)
+"Uu" = (
+/obj/structure/lattice,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Uw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/mahogany,
@@ -11483,6 +12149,10 @@
 	},
 /turf/open,
 /area/ministation/maint/l3se)
+"Vf" = (
+/obj/structure/bed/chair/armchair/black,
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Vi" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
@@ -11946,7 +12616,10 @@
 	emote_see = list("screams and flaps its wings","pecks viciously at the air");
 	emote_speech = list("Honk!", "HONK!!", "HONKhonkHONK!!!", "HOOOOOONK!!!", "AAAIIIIGHHH!!!!!", "AUGHHH!!!", "HONK HONK HONKITYhonkHONKhonkHONK!!!");
 	move_speed = 15;
-	color = "#5fffdd"
+	color = "#5fffdd";
+	max_health = 42;
+	harm_intent_damage = 30;
+	speak_emote = list("screams and flaps its wings","pecks viciously at the air","honks","honks... HONKS","honks loudly","screams", "reprimands the nearest person with a loud scream")
 	},
 /turf/simulated/floor/bluegrid,
 /area/ministation/bridge/vault)
@@ -11970,6 +12643,10 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/usedup,
 /area/ministation/enclave/foyer)
@@ -12022,7 +12699,6 @@
 	dir = 1;
 	pixel_y = 26
 	},
-/obj/item/soap,
 /turf/unsimulated/floor,
 /area/ministation/enclave/matriarch)
 "Xi" = (
@@ -12034,6 +12710,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/red,
 /area/ministation/court)
+"Xj" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "_North APC";
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/ministation/enclave/conference)
 "Xk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -12078,6 +12772,9 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"Xw" = (
+/turf/simulated/wall/r_wall,
+/area/ministation/enclave/conference)
 "XA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -12179,6 +12876,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ministation/science)
+"XT" = (
+/obj/structure/lattice,
+/obj/item/chems/food/meatball{
+	filling_color = "#000099";
+	color = "#000099";
+	desc = "...You feel like you've met this one before.";
+	name = "blue meatball";
+	nutriment_type = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	nutriment_desc = list("hell" = 1);
+	germ_level = 9001;
+	material = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	matter = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25)
+	},
+/turf/space,
+/area/space)
 "XU" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -12669,6 +13381,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/ministation/biodome)
+"ZF" = (
+/obj/machinery/door/window/westleft,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "mfloor4"
+	},
+/turf/simulated/floor/tiled,
+/area/ministation/science)
 "ZH" = (
 /obj/effect/floor_decal/carpet/green,
 /turf/simulated/floor/wood/walnut,
@@ -32136,7 +32858,7 @@ eJ
 fq
 hW
 FN
-AP
+FN
 QM
 FA
 eJ
@@ -32393,7 +33115,7 @@ eJ
 ut
 vx
 Wd
-Wd
+JR
 QV
 Bg
 eJ
@@ -34449,13 +35171,13 @@ ad
 ad
 aa
 aa
-cw
-cw
-cw
-cw
-cw
-cw
-cw
+Xw
+Xw
+oo
+oo
+oo
+Xw
+Xw
 ad
 aa
 aa
@@ -34706,13 +35428,13 @@ ad
 ad
 ad
 aa
-cw
-cw
-cw
-cw
-cw
-cw
-cw
+Xw
+Xj
+yW
+ha
+Lt
+GZ
+Xw
 aa
 aa
 aa
@@ -34963,13 +35685,13 @@ Ew
 Ew
 Ew
 Ew
-Ew
-cw
-cw
-cw
-cw
-cw
-cw
+Xw
+yV
+Vf
+zz
+qM
+ep
+hZ
 aa
 aa
 aa
@@ -35220,13 +35942,13 @@ NA
 NA
 NA
 NA
-Ew
-hE
-cw
-cw
-cw
-cw
-cw
+Oi
+Uu
+Vf
+qM
+Kp
+ep
+hZ
 aa
 aa
 aa
@@ -35477,13 +36199,13 @@ NA
 NA
 NA
 NA
-Ew
-hE
-hE
-cw
-cw
-cw
-cw
+Oi
+hw
+Vf
+qM
+Td
+ep
+hZ
 aa
 aa
 aa
@@ -35734,13 +36456,13 @@ dV
 tD
 oz
 uY
-ru
-hE
-cw
-cw
-cw
-cw
-cw
+Ii
+Iy
+Vf
+qM
+qM
+ep
+hZ
 aa
 aa
 aa
@@ -35991,13 +36713,13 @@ wv
 yY
 yY
 NL
-ru
-hE
-cw
-cw
-cw
-cw
-cw
+nb
+sz
+yW
+KH
+Dq
+lR
+Xw
 hE
 aa
 aa
@@ -36248,13 +36970,13 @@ Uj
 qD
 qD
 HZ
-Ol
-SM
-SM
-cw
-cw
-hE
-cw
+rU
+Xw
+Xw
+Xw
+Xw
+rU
+Xw
 cw
 aa
 aa
@@ -39075,7 +39797,7 @@ Xs
 lO
 lO
 Xs
-ad
+XT
 aa
 aa
 aa
@@ -39582,9 +40304,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-lO
+Xs
+Xs
+Xs
 hk
 Lj
 zm
@@ -39839,9 +40561,9 @@ aa
 aa
 aa
 aa
-aa
-aa
 lO
+JS
+Ea
 oW
 pk
 Ej
@@ -40096,8 +40818,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+lO
+hk
 Xs
 Xs
 Xs
@@ -40353,13 +41075,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-ad
-ad
-aa
+lO
+yF
+PC
+PC
+KO
+lO
+cw
 aa
 aa
 aa
@@ -40610,12 +41332,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-ad
+lO
+yF
+tG
+tG
+gb
+lO
 ad
 aa
 aa
@@ -40867,12 +41589,12 @@ aa
 af
 af
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+lO
+Pr
+DU
+DU
+Sr
+lO
 ad
 ad
 aa
@@ -41124,12 +41846,12 @@ aa
 af
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xs
+lO
+lO
+lO
+lO
+Xs
 aa
 ad
 ad
@@ -56332,7 +57054,7 @@ IE
 Hv
 ae
 XR
-dy
+ZF
 ef
 ae
 mn
@@ -56845,13 +57567,13 @@ JX
 IE
 Hv
 ae
-dd
-dd
-aw
+qZ
+xp
+pR
 ae
-dd
-dd
-aw
+iL
+iL
+tl
 ae
 CX
 CX
@@ -57102,11 +57824,11 @@ qA
 hu
 jU
 ae
-dd
+MX
 Ka
-aw
+Ph
 ae
-dd
+iL
 du
 aw
 ae
@@ -57359,11 +58081,11 @@ Pp
 EU
 XP
 ae
-dd
-dA
-eh
+wI
+so
+Fs
 ae
-dd
+iL
 dA
 eh
 ae
@@ -57615,15 +58337,15 @@ ae
 ae
 ae
 ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
-ae
+dz
+dz
+GV
+dz
+dz
+dz
+dz
+dz
+dz
 aa
 aa
 aa
@@ -57872,15 +58594,15 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
+SK
+um
+Nv
+yr
+AP
+oM
+iD
+Kx
+SK
 aa
 aa
 aa
@@ -58129,15 +58851,15 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
+SK
+EY
+Es
+ra
+SK
+dz
+SK
+qF
+SK
 aa
 aa
 aa
@@ -58386,15 +59108,15 @@ cw
 cw
 cw
 cw
+SK
+SK
+SK
+SK
+SK
 cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
-cw
+SK
+SK
+SK
 aa
 aa
 aa

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -4177,6 +4177,12 @@
 	icon_state = "dir_splatter_2";
 	dir = 9
 	},
+/obj/item/chems/drinks/zombiedrink{
+	color = "#600000";
+	desc = "Oh no.";
+	name = "Clown-Shaped Vial";
+	germ_level = 9001
+	},
 /mob/living/simple_animal/hostile/retaliate/clown{
 	color = "#600000";
 	name = "We, by Yingksy";
@@ -4184,53 +4190,49 @@
 	emote_see = list("screams incoherently");
 	emote_speech = list("HAaaAAAUGHNNK!!!","HAAWAAAWAUUGHHNNKKGG!!!", "hhhhHHHHAAAAUUUGGHHHNNNKK!!!!!", "hhhHHhhhhHAAAAUGGHHHGhhhAAAUUGHhhhHHAAAAUGHHHNnggnnkk!!!!!");
 	bleed_colour = "#000000";
-	move_speed = 1;
+	move_speed = 2;
 	max_health = 9001;
 	minbodytemp = -666;
 	maxbodytemp = 666;
-	mob_size = 25;
+	mob_size = 50;
 	death_message = "gurgles hideously and drops to the floor!";
 	break_stuff_probability = 50;
 	cold_damage_per_tick = 1;
 	emote_hear = list("cackles horrendously");
 	faction = "He";
 	friendly = "";
-	harm_intent_damage = 15;
+	harm_intent_damage = 50;
 	heat_damage_per_tick = 1;
 	climb_speed_mult = 3;
 	hydration = 9001;
 	meat_amount = 20;
 	throw_range = 15;
 	throw_speed = 5;
-	speak_chance = 10;
+	speak_chance = 25;
 	see_invisible = 100;
 	see_infrared = 100;
 	see_in_dark = 100;
 	response_disarm = "";
-	response_harm = list("slashes", "shreds", "tears", "rips", "gores");
+	response_harm = list("claws desperately");
 	response_help_1p = "";
 	response_help_3p = "";
 	pry_desc = list("prying", "pushing", "ripping", "smashing");
-	pry_time = 45;
-	reagents = list(/decl/material/liquid/nutriment = 10, /decl/material/liquid/amphetamines = 30, /decl/material/liquid/zombie = 20, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	pry_time = 90;
 	ranged_range = 12;
-	glowing_eyes = 1;
+	glowing_eyes = 2;
 	germ_level = 9001;
 	fire_desc = "";
-	can_pull_size = 60;
+	can_pull_size = 120;
 	can_buckle = 1;
 	bone_amount = 10;
 	blood_type = "X";
 	unsuitable_atmos_damage = 1;
 	nutrition = 9001;
 	bodytemperature = 0;
-	speak_emote = list("screeches")
-	},
-/obj/item/chems/drinks/zombiedrink{
-	color = "#600000";
-	desc = "Oh no.";
-	name = "Clown-Shaped Vial";
-	germ_level = 9001
+	speak_emote = list("screeches", "shrieks", "cackles", "rasps");
+	shakecamera = 1;
+	move_to_delay = 2;
+	step_size = 8
 	},
 /turf/exterior/mud{
 	color = "#600000";
@@ -9352,26 +9354,25 @@
 	emote_hear = list("cackles horrendously");
 	faction = "He";
 	friendly = "";
-	harm_intent_damage = 15;
+	harm_intent_damage = 25;
 	heat_damage_per_tick = 1;
 	climb_speed_mult = 3;
 	hydration = 9001;
 	meat_amount = 20;
 	throw_range = 15;
 	throw_speed = 5;
-	speak_chance = 10;
+	speak_chance = 25;
 	see_invisible = 100;
 	see_infrared = 100;
 	see_in_dark = 100;
 	response_disarm = "";
-	response_harm = list("slashes", "shreds", "tears", "rips", "gores");
+	response_harm = list("claws desperately");
 	response_help_1p = "";
 	response_help_3p = "";
 	pry_desc = list("prying", "pushing", "ripping", "smashing");
 	pry_time = 45;
-	reagents = list(/decl/material/liquid/nutriment = 10, /decl/material/liquid/amphetamines = 30, /decl/material/liquid/zombie = 20, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
 	ranged_range = 12;
-	glowing_eyes = 1;
+	glowing_eyes = 2;
 	germ_level = 9001;
 	fire_desc = "";
 	can_pull_size = 60;
@@ -9381,7 +9382,10 @@
 	unsuitable_atmos_damage = 1;
 	nutrition = 9001;
 	bodytemperature = 0;
-	speak_emote = list("screeches")
+	speak_emote = list("screeches", "shrieks", "cackles", "rasps");
+	shakecamera = 1;
+	move_to_delay = 8;
+	step_size = 16
 	},
 /obj/effect/decal/cleanable/blood{
 	icon_state = "mfloor2"

--- a/maps/ministation/ministation-3.dmm
+++ b/maps/ministation/ministation-3.dmm
@@ -1499,6 +1499,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/ministation/enclave/eggclave)
+"Ai" = (
+/obj/structure/lattice,
+/obj/item/chems/food/meatball{
+	filling_color = "#000099";
+	color = "#000099";
+	desc = "...You feel like you've met this one before.";
+	name = "blue meatball";
+	nutriment_type = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	nutriment_desc = list("hell" = 1);
+	germ_level = 9001;
+	material = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25);
+	matter = list(/decl/material/liquid/nutriment = 1, /decl/material/liquid/amphetamines = 3, /decl/material/liquid/zombie = 2, /decl/material/liquid/psychoactives = 15, /decl/material/liquid/hallucinogenics = 25)
+	},
+/turf/space,
+/area/space)
 "Aj" = (
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -2317,10 +2332,6 @@
 	pixel_y = 12;
 	pixel_x = -13
 	},
-/obj/structure/mirror{
-	pixel_y = 4;
-	pixel_x = -24
-	},
 /obj/machinery/light{
 	dir = 2
 	},
@@ -2795,6 +2806,9 @@
 	pixel_y = 14
 	},
 /obj/structure/emergency_dispenser/south,
+/obj/structure/mirror{
+	pixel_y = 29
+	},
 /turf/simulated/floor/tiled,
 /area/ministation/enclave/eggclave)
 "XQ" = (
@@ -24577,13 +24591,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -24834,13 +24848,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -25092,12 +25106,12 @@ ly
 ly
 ly
 ly
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -25349,12 +25363,12 @@ fG
 fG
 fG
 ly
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -25606,12 +25620,12 @@ fG
 fG
 fG
 ly
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -25863,12 +25877,12 @@ fG
 fG
 fG
 ly
-uG
-aa
-aa
-aa
-aa
-aa
+Cg
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -26120,12 +26134,12 @@ MQ
 zz
 iD
 SM
-uG
-uG
-aa
-aa
-aa
-aa
+Cg
+Cg
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -26379,10 +26393,10 @@ eW
 Wk
 cw
 cw
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -27138,7 +27152,7 @@ aa
 aa
 af
 oP
-uG
+Ai
 uG
 aa
 aa
@@ -29710,8 +29724,8 @@ aa
 aa
 af
 aa
-aa
-aa
+cw
+cw
 cw
 cw
 cw
@@ -29967,8 +29981,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 cw
 cw
 cw
@@ -30224,8 +30238,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+cw
+cw
 cw
 cw
 cw
@@ -30481,12 +30495,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -30738,12 +30752,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -30995,12 +31009,12 @@ aa
 aa
 af
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -31252,12 +31266,12 @@ aa
 af
 af
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -48000,15 +48014,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -48257,15 +48271,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 aa
 aa
 aa
@@ -48514,15 +48528,15 @@ aa
 aa
 aa
 aa
+cw
+cw
+cw
+cw
+cw
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+cw
+cw
+cw
 aa
 aa
 aa

--- a/maps/ministation/ministation_areas.dm
+++ b/maps/ministation/ministation_areas.dm
@@ -455,6 +455,12 @@
 	icon_state = "white"
 	secure = TRUE
 
+/area/ministation/enclave/conference
+	name = "\improper Table of Meeting"
+	req_access = list(access_security)
+	icon_state = "green"
+	secure = TRUE
+
 
 /area/ministation/Arrival
 	name = "\improper Arrival Shuttle" // I hate this ugly thing


### PR DESCRIPTION
- Added Enclave Table Room (??? it has a table and big windows, what do you want from me???) 
- Made the clown and goose more talkative (hopefully!) 
- Added cheery decorations to the clown's room (yay!) 
- Spraypainted everyone's impossible dreams gold (snazzy!) 
- made the Bast Fastard red (it's the fastest colour you know!) 
- Added commemorative clown toys to medical (because if you work there, you'll definitely prefer a toy clown over the real deal!) 
- Found Gikka's Lost Pen (yay)
- Lost Gikka's Pen (aw)
- Probably broke the Enclave airlock even more (YAY) 
- Gave names to a couple critters (they so fuzzy!)
- Added more tube things to trans your its to the place be am what of (probably!) 
- Enclave tower got stairs (OO FANCY)
- Spookums is now a Yingksy brand, like that one sock monkey fashion line thing (Julio? Jumbly? idfk) 
- Properly named the Matriarch's privacy shutters (oo la la) 
- MEATBALLS ARE STILL BLUE (and still do nothing, but at least they're blue) (BLOO) 
- Fixed the broken fixed broken thing (??????)

This is gonna be my last big update until I finish a few away site ideas I've had. I'll also probably absorb the correct PR formatting by then, sorry about the mess every time I do a PR. I'll be better about it next time.