### PR TITLE
Tweaks to Colony and Pod away sites

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -217,7 +217,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "ar" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 0
+	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -317,7 +319,7 @@
 	},
 /obj/machinery/airlock_sensor{
 	dir = 4;
-	pixel_x = -15;
+	pixel_x = -18;
 	id_tag = "crashed_pod_sensor"
 	},
 /obj/effect/floor_decal/industrial/hatch/orange,
@@ -1307,7 +1309,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airlock_sensor{
 	dir = 4;
-	pixel_x = -15;
+	pixel_x = -17;
 	id_tag = "crashed_pod_int_sensor"
 	},
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -5433,7 +5433,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/hydroponics,
+/obj/structure/closet/secure_closet/hydroponics{
+	anchored = 1;
+	locked = 0;
+	req_access = null
+	},
 /obj/item/chems/glass/bucket,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
@@ -6213,7 +6217,7 @@
 /area/map_template/colony)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+	dir = 4
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -6236,7 +6240,9 @@
 	pixel_x = 19;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /obj/structure/catwalk,
 /obj/structure/cable{
 	desc = "A flexible superconducting cable for heavy-duty power transfer. It's been labeled 'chaos reigns'.";
@@ -6247,9 +6253,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/closet/emcloset,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/suit/space/emergency,
@@ -6259,7 +6262,7 @@
 "mb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "mc" = (
@@ -6304,7 +6307,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/colony/jail)
 "mg" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -6967,9 +6970,7 @@
 /turf/simulated/floor/grass,
 /area/map_template/colony/hydroponics)
 "nt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/wall/r_wall,
 /area/map_template/colony/airlock)
 "nu" = (
@@ -7200,14 +7201,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
-	id_tag = "playablecolonymain_pump_out_internal";
-	power_rating = 25000
-	},
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -21
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
+	id_tag = "playablecolonymain_pump";
+	power_rating = 25000
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
@@ -7254,8 +7254,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "playablecolonymain_pump";
+	id_tag = "playablecolonymain_pump_out_internal";
 	power_rating = 25000
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7274,8 +7273,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 1;
-	id_tag = "playablecolonymain_pump";
+	id_tag = "playablecolonymain_pump_out_internal";
 	power_rating = 25000
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -7450,16 +7448,6 @@
 	desc = "A large, unwieldy bolt-action rifle in shoddy condition. Chambered in small caliber, looks far scarier than it is. Vamoos ya varmint!";
 	name = "anti-varmint rifle"
 	},
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
-/obj/item/ammo_magazine/pistol/small,
 /obj/machinery/door/window/northright,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7467,6 +7455,107 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/projectile/bullet/rifle,
+/obj/item/stock_parts/ammo_box,
 /turf/exterior/concrete,
 /area/map_template/colony/mineralprocessing)
 "ok" = (
@@ -7594,9 +7683,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
 "ov" = (
@@ -7624,7 +7711,7 @@
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/airlock)
@@ -7639,7 +7726,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
-	dir = 8;
 	id_tag = "playablecolonymain_pump_out_internal";
 	power_rating = 25000
 	},
@@ -7667,7 +7753,9 @@
 "oA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
 /obj/structure/catwalk,
 /turf/exterior/concrete,
 /area/map_template/colony/mineralprocessing)
@@ -7893,6 +7981,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/map_template/colony/hydroponics)
+"Hu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_borosilicate,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/plating,
+/area/map_template/colony/airlock)
 "Hy" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/power/apc{
@@ -8005,6 +8099,12 @@
 "Ot" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/colony/bathroom)
+"Rf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/wall/r_wall,
+/area/map_template/colony/airlock)
 "RR" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -8022,6 +8122,14 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/hydroponics)
+"VV" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced_borosilicate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/map_template/colony/airlock)
 "Xh" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -8851,10 +8959,10 @@ kI
 kq
 ky
 nV
-nt
+bh
 lh
 ow
-bh
+Rf
 bh
 or
 "}
@@ -8895,7 +9003,7 @@ mw
 nO
 ou
 ox
-mw
+Hu
 mZ
 os
 "}
@@ -8936,7 +9044,7 @@ bd
 lJ
 mb
 nS
-bh
+nt
 nm
 os
 "}
@@ -8977,7 +9085,7 @@ aJ
 lM
 mg
 nU
-mw
+VV
 nq
 os
 "}


### PR DESCRIPTION
Attempting a partial fix for Pod airlock, tank is now empty so when it vents internal atmosphere, it will at least quickly fill instead of hang when trying to exit. Still looking into solutions for external entry hang, however.

Colony airlock now has three vents each for internal and external pressure. Internal venting will be a bit slower, but external venting should be faster now too.

Fixed a couple locks in the Hydroponics bay on Colony. No more smashing lockers to get farm tools.