### PR TITLE
remove species whitelist from valsal overrides

### DIFF
--- a/mods/valsalia/map/overrides.dm
+++ b/mods/valsalia/map/overrides.dm
@@ -1,8 +1,8 @@
 /datum/job/submap
-	whitelisted_species = list(SPECIES_HUMAN, SPECIES_YINGLET)
+	//whitelisted_species = list(SPECIES_HUMAN, SPECIES_YINGLET)
 
 /decl/submap_archetype
-	whitelisted_species = list(SPECIES_HUMAN, SPECIES_YINGLET)
+	//whitelisted_species = list(SPECIES_HUMAN, SPECIES_YINGLET)
 
 /datum/map/tradeship
 	lobby_tracks = list(/decl/music_track/zazie)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
removes submap species restrictions from valsalia\map\overrides.dm

## Why and what will this PR improve
lets you spawn on away missions as any species

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
bugfix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->