### PR TITLE
Baxxid species mouth dexterity buff

### DIFF
--- a/mods/valsalia/species/baxxid.dm
+++ b/mods/valsalia/species/baxxid.dm
@@ -167,7 +167,7 @@
 						word += ch + ch // capitalized
 			else
 				word += c+c
-			k *= 0.8	
+			k *= 0.8
 		message = copytext_char(message, 2)
 	switch(text2ascii(uppertext(ch)))
 		if (65 to 90)
@@ -257,6 +257,9 @@
 
 /obj/item/organ/external/hand/right/baxxid/get_manual_dexterity()
 	return (DEXTERITY_HOLD_ITEM|DEXTERITY_SIMPLE_MACHINES|DEXTERITY_KEYBOARDS)
+
+/obj/item/organ/external/head/get_manual_dexterity()
+	return (DEXTERITY_FULL)
 
 /datum/inventory_slot/gripper/left_hand/baxxid
 	can_use_held_item = FALSE


### PR DESCRIPTION
Alteration of the baxxid mouth dexterity bitflag -- previously they could do some tasks with the various tools in-game, such as use the crowbar, screwdriver etc., but were oddly unable to consume most food items, water in cups, and use a few other miscellaneous things.

Testing with using various tools/items and doing construction seems to have retained all restrictions with the right/left hands, I assume due to the 'can_use_held_item' flag being set to false for both of them.