### PR TITLE
Remove the ability for baxxid to use guns/firearms.

### DIFF
--- a/mods/valsalia/species/baxxid.dm
+++ b/mods/valsalia/species/baxxid.dm
@@ -260,7 +260,7 @@
 	return (DEXTERITY_HOLD_ITEM|DEXTERITY_SIMPLE_MACHINES|DEXTERITY_KEYBOARDS)
 
 /obj/item/organ/external/head/baxxid/get_manual_dexterity()
-	return (DEXTERITY_FULL)
+	return (DEXTERITY_FULL & ~(DEXTERITY_WEAPONS))
 
 /datum/inventory_slot/gripper/left_hand/baxxid
 	dexterity = (DEXTERITY_HOLD_ITEM|DEXTERITY_SIMPLE_MACHINES|DEXTERITY_KEYBOARDS)


### PR DESCRIPTION
An oversight when altering the baxxid dexterity is that they could now use guns and other firearms, which unbalances them compared to other ingame species. AND-NOT-ing DEXTERITY_FULL with DEXTERITY_WEAPONS appears to fix this issue. Melee tools such as the crowbar or katana seem to still function from testing it on a private server.
