### PR TITLE
Add natural baxxid space resistance, so they can do their jobs.

### DIFF
--- a/mods/valsalia/species/baxxid.dm
+++ b/mods/valsalia/species/baxxid.dm
@@ -84,6 +84,13 @@
 		/decl/natural_attack/bite/strong
 	)
 
+	warning_low_pressure = 50
+	hazard_low_pressure = -1
+
+	natural_armour_values = list(
+		ARMOR_BIO = ARMOR_BIO_SHIELDED
+	)
+
 	base_external_prosthetics_model = null
 	preview_outfit = /decl/outfit/baxxid
 


### PR DESCRIPTION
Baxxid are unable to wear space suits and it seems other species incapable of doing so are typically given space resistance--in particular the "serpentids" here (though other codebases with other species seem to follow this general rule as well), see [mods/species/serpentid/datum/species.dm:natural_armour_values].
