### PR TITLE
Tweak baxxid species stats.

### DIFF
--- a/mods/valsalia/species/baxxid.dm
+++ b/mods/valsalia/species/baxxid.dm
@@ -87,9 +87,19 @@
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
 
+	shock_vulnerability = 0.05262
+	strength = STR_HIGH
+
 	natural_armour_values = list(
-		ARMOR_BIO = ARMOR_BIO_SHIELDED
+		ARMOR_BIO = ARMOR_BIO_SHIELDED,
+		ARMOR_RAD = 0.5*ARMOR_RAD_MINOR
 	)
+
+	gluttonous = 4
+	stomach_capacity = 15
+	hunger_factor = 0.06
+	thirst_factor = 0.06
+	blood_volume = 655
 
 	base_external_prosthetics_model = null
 	preview_outfit = /decl/outfit/baxxid


### PR DESCRIPTION
Added natural amount of insulation so basic wiring can be done with only mild--moderate burns at most, rather than severe and deadly ones which cause the unfortunate baxxid to collapse and die.

The baxxid species size was set to large but their ambient strength was still set to the same value as a default human for some reason--changed from 'STR_MEDIUM' to 'STR_HIGH'.

Added slight radiation protection, which when tested is less effective than wearing a radiation suit (which the baxxid species can not fit into currently). Makes it possible for baxxid to work in slightly radioactive regions without suffering guaranteed fatal radiation poisoning.

Altered blood volume and hunger depletion to more (at least, in my opinion) accurately represent their size, as by default they have the same values as a human. Blood volume also increased slightly as they would likely have more blood than a human.
