### PR TITLE
Fix surgery checking surgeon's body covered instead of patient's

### DIFF
--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -148,9 +148,9 @@ var/global/list/surgery_tool_exception_cache = list()
 				 affected.how_open() < open_threshold))
 					return FALSE
 			// Check if clothing is blocking access
-			var/obj/item/I = user.get_covering_equipped_item_by_zone(target_zone)
+			var/obj/item/I = target.get_covering_equipped_item_by_zone(target_zone)
 			if(I && (I.item_flags & ITEM_FLAG_THICKMATERIAL))
-				to_chat(user,SPAN_NOTICE("The material covering this area is too thick for you to do surgery through!"))
+				to_chat(user,SPAN_NOTICE("The material covering this area (\the [I.name]) is too thick for you to do surgery through!"))
 				return FALSE
 			return affected
 	return FALSE


### PR DESCRIPTION
Fixes an issue where if the surgeon was wearing a thick material on a body part, they would be unable to perform surgery on a patient even if the patient wasn't wearing anything.

Also added to the failure message a section that explains what item is blocking the surgery, removing guesswork.

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Line 151 of code/modules/surgery/_surgery.dm incorrectly checked `user.get_covering_equipped_item_by_zone(target_zone)` instead of `target.get_covering_equipped_item_by_zone(target_zone)`.
Line 153 has been modified to add "`(\the [I.name])`" to the failure message regarding the material being too thick to do surgery through.  This removes guesswork by letting the surgeon know exactly what item needs to be removed in order to proceed.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Surgery was strange and inconsistent previously, with being randomly denied the ability to work for seemingly no reason.  When the reason was discovered, it made little to no sense, and seemed wildly unintentional.  A doctor wearing armor should not be prevented from operating on a naked patient, and a naked doctor should not be allowed to operate on an armored patient.
The addition to the failure message helps clarify things, which may be especially helpful during stressful moments such as a medical emergency, or to help a player new to medicine learn the system.

## Authorship
<!-- Describe original authors of changes to credit them. -->
These two lines changed by Typhin.

## Changelog
:cl:
bugfix: Fixed surgery checking wrong body for blocking coverings
tweak: Tweaked the failure message to increase clarity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->