### PR TITLE
Fix exhaling not working when not holding your breath

### DIFF
--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -144,7 +144,7 @@
 
 /mob/living/proc/handle_post_breath(datum/gas_mixture/breath)
 
-	if(!breath || !holding_breath)
+	if(!breath || holding_breath)
 		return
 
 	var/datum/gas_mixture/loc_air = loc?.return_air()


### PR DESCRIPTION
The check was backwards so you only breathed out when holding your breath.