### PR TITLE
Summit, Overrun Colony (Hateville) mob counts reduced.

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/hateville/hateville.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hateville/hateville.dmm
@@ -1296,7 +1296,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/techfloor,
 /area/map_template/hateville/common)
 "cc" = (
@@ -2792,6 +2791,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/techfloor,
 /area/map_template/hateville/power)
 "ej" = (
@@ -3368,7 +3368,6 @@
 	pixel_y = 17;
 	pixel_x = 12
 	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/techfloor,
 /area/map_template/hateville/power)
 "eV" = (
@@ -3981,7 +3980,7 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/abstract/landmark/corpse/marooned_officer,
+/obj/item/remains/human,
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "#a10808"
 	},
@@ -4009,11 +4008,9 @@
 /turf/floor/holofloor/tiled/stone,
 /area/map_template/hateville/power)
 "fG" = (
-/obj/structure/flora/bush/fullgrass,
-/obj/effect/decal/cleanable/dirt/visible,
-/mob/living/bot/farmbot,
-/turf/floor/grass,
-/area/map_template/hateville/agricultureOU)
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
+/turf/floor/tiled/white,
+/area/map_template/hateville/medical)
 "fH" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -4648,18 +4645,6 @@
 /obj/machinery/power/solar,
 /turf/floor/tiled/techfloor/grid,
 /area/template_noop)
-"gD" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
-/turf/floor/tiled/techfloor/grid,
-/area/map_template/hateville/command)
 "gE" = (
 /obj/abstract/landmark/corpse/scientist,
 /obj/effect/decal/cleanable/blood/gibs{
@@ -5604,6 +5589,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt/visible,
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#6b2b2b"
 	},
@@ -8150,7 +8136,7 @@
 /obj/structure/defensive_barrier{
 	dir = 8
 	},
-/obj/abstract/landmark/corpse/marooned_officer,
+/obj/item/remains/human,
 /obj/effect/decal/cleanable/blood/tracks/footprints{
 	color = "#a10808"
 	},
@@ -8313,7 +8299,6 @@
 "lV" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#bbc9e5"
 	},
@@ -8540,7 +8525,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/vomit,
 /obj/item/wrench,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /obj/random/trash,
 /turf/floor/tiled/white{
 	color = "#bbc9e5"
@@ -8934,12 +8918,12 @@
 /turf/floor/concrete/reinforced/road,
 /area/template_noop)
 "mQ" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 4
+	},
 /mob/living/simple_animal/aggressive/prosyletizing_employist,
-/turf/floor/concrete,
-/area/map_template/hateville/materials)
+/turf/floor/carpet/blue,
+/area/map_template/hateville/command)
 "mR" = (
 /obj/item/flashlight/upgraded,
 /obj/item/crowbar,
@@ -11076,7 +11060,7 @@
 	color = "#223245"
 	},
 /obj/item/chems/syringe/antitoxin,
-/obj/abstract/landmark/corpse/marooned_officer,
+/obj/item/remains/human,
 /obj/item/gun/projectile/pistol/holdout,
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "#a10808"
@@ -11685,11 +11669,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/template_noop,
 /area/template_noop)
-"rS" = (
-/obj/structure/flora/bush/ppflowers,
-/mob/living/bot/farmbot,
-/turf/floor/grass,
-/area/map_template/hateville/agricultureOU)
 "rT" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -11722,7 +11701,6 @@
 	dir = 4
 	},
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/wood/mahogany,
 /area/map_template/hateville/command)
 "rX" = (
@@ -11830,7 +11808,6 @@
 /obj/effect/decal/cleanable/blood/tracks/footprints{
 	color = "#a10808"
 	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#6b2b2b"
 	},
@@ -13789,7 +13766,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#6b2b2b"
 	},
@@ -14566,6 +14542,7 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/concrete/reinforced/road,
 /area/map_template/hateville/mining)
 "xY" = (
@@ -15687,7 +15664,6 @@
 	dir = 4
 	},
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/concrete,
 /area/template_noop)
 "AA" = (
@@ -15850,7 +15826,6 @@
 	dir = 4
 	},
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white,
 /area/map_template/hateville/medical)
 "AT" = (
@@ -16417,7 +16392,6 @@
 	color = "#a10808"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /obj/random/trash,
 /turf/floor/tiled/white,
 /area/map_template/hateville/medical)
@@ -16480,7 +16454,7 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/abstract/landmark/corpse/marooned_officer,
+/obj/item/remains/human,
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "#a10808"
 	},
@@ -17647,6 +17621,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#6b2b2b"
 	},
@@ -19884,7 +19859,6 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_magazine/pistol/small,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /obj/random/trash,
 /turf/floor/tiled/white{
 	color = "#d9d9be"
@@ -20530,7 +20504,6 @@
 	color = "#a10808"
 	},
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /obj/structure/cable{
 	icon_state = "1-8";
 	dir = 4
@@ -20848,14 +20821,6 @@
 	},
 /turf/floor/concrete,
 /area/template_noop)
-"Ml" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
-/turf/floor/concrete/reinforced/road,
-/area/template_noop)
 "Mm" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -21035,7 +21000,6 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/holofloor/tiled/stone,
 /area/template_noop)
 "MG" = (
@@ -21348,7 +21312,7 @@
 	allowed_magazines = /obj/item/ammo_magazine/pistol/small
 	},
 /obj/item/ammo_magazine/pistol/small,
-/obj/abstract/landmark/corpse/marooned_officer,
+/obj/item/remains/human,
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "#a10808"
 	},
@@ -21687,12 +21651,6 @@
 /obj/effect/floor_decal/techfloor/corner,
 /turf/floor/holofloor/tiled/stone,
 /area/map_template/hateville/environment)
-"Oo" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt/visible,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
-/turf/floor/concrete,
-/area/template_noop)
 "Op" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -21894,7 +21852,6 @@
 /obj/effect/decal/cleanable/blood/tracks/footprints{
 	color = "#a10808"
 	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#6b2b2b"
 	},
@@ -22491,6 +22448,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#dadada"
 	},
@@ -23271,7 +23229,6 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/gun/projectile/pistol/holdout,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/techfloor,
 /area/map_template/hateville/power)
 "Rw" = (
@@ -24498,7 +24455,6 @@
 	color = "#a10808"
 	},
 /obj/item/ammo_magazine/pistol/small,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white{
 	color = "#d9d9be"
 	},
@@ -26115,7 +26071,6 @@
 	dir = 1
 	},
 /obj/random/trash,
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/white,
 /area/map_template/hateville/medical)
 "XK" = (
@@ -26864,7 +26819,6 @@
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "#a10808"
 	},
-/mob/living/simple_animal/aggressive/prosyletizing_employist,
 /turf/floor/tiled/old_tile,
 /area/map_template/hateville/agriculture)
 "YX" = (
@@ -28256,7 +28210,7 @@ Cf
 hr
 is
 EG
-bh
+fG
 jy
 hr
 bh
@@ -29428,7 +29382,7 @@ ac
 CM
 WQ
 bn
-vj
+mQ
 CM
 Bh
 aa
@@ -29489,7 +29443,7 @@ vk
 kN
 cv
 qF
-Ml
+ah
 nm
 lw
 Rx
@@ -29627,7 +29581,7 @@ Mp
 TX
 vk
 jW
-mQ
+ZO
 zw
 OJ
 ui
@@ -29858,7 +29812,7 @@ bp
 VL
 aH
 eG
-gD
+eD
 eD
 eP
 aH
@@ -30533,7 +30487,7 @@ ts
 sL
 fw
 ym
-Oo
+fc
 af
 "}
 (46,1,1) = {"
@@ -31218,7 +31172,7 @@ Wq
 Zc
 yO
 fY
-rS
+wm
 oy
 OG
 NZ
@@ -31940,7 +31894,7 @@ yO
 fY
 yV
 vJ
-fG
+OG
 vJ
 LA
 kd

--- a/maps/random_ruins/exoplanet_ruins/summit/summit.dmm
+++ b/maps/random_ruins/exoplanet_ruins/summit/summit.dmm
@@ -237,21 +237,10 @@
 	temperature = 0
 	})
 "bw" = (
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
-	},
 /obj/structure/defensive_barrier,
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
-	},
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/concrete/reinforced,
 /area/map_template/summit{
@@ -612,19 +601,8 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/clothing/shoes/avian/footwraps,
 /obj/item/organ/external/tail/avian,
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib1"
-	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
-	},
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/unsimulated/floor/freezer,
@@ -731,30 +709,6 @@
 	germ_level = 800000000;
 	temperature = 0
 	})
-"dL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
-	},
-/obj/machinery/status_display{
-	pixel_y = 34
-	},
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
-	},
-/obj/effect/decal/cleanable/dirt/visible,
-/turf/unsimulated/floor/freezer,
-/area/map_template/summit{
-	germ_level = 800000000;
-	temperature = 0
-	})
 "dU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -824,6 +778,10 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/barricade/spike{
+	dir = 1;
+	material = /decl/material/solid/metal/steel
+	},
 /turf/floor/cult,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -928,6 +886,10 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	dir = 4;
+	pixel_x = -45
+	},
 /turf/floor/greengrid,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -977,6 +939,9 @@
 	enabled = 0
 	},
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/radioactive/alt{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/freezer,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -1006,10 +971,6 @@
 	icon_state = "u_dangerous_l"
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/barricade/spike{
-	dir = 1;
-	material = /decl/material/solid/metal/steel
-	},
 /turf/floor/concrete/reinforced,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -1273,7 +1234,7 @@
 	temperature = 0
 	})
 "gP" = (
-/obj/machinery/recharge_station,
+/obj/machinery/constructable_frame,
 /obj/structure/cable{
 	icon_state = "1-8";
 	dir = 4
@@ -1381,10 +1342,6 @@
 	},
 /obj/effect/decal/cleanable/blood{
 	icon_state = "mfloor7"
-	},
-/obj/structure/barricade/spike{
-	dir = 1;
-	material = /decl/material/solid/metal/steel
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1734,19 +1691,8 @@
 	temperature = 0
 	})
 "jy" = (
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
-	},
 /obj/structure/defensive_barrier{
 	dir = 8
-	},
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -2293,6 +2239,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/dark,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -2855,18 +2804,6 @@
 	germ_level = 800000000;
 	temperature = 0
 	})
-"pJ" = (
-/mob/living/simple_animal/aggressive/humborg{
-	glowing_eyes = 1;
-	attack_delay = 30;
-	base_movement_delay = 5
-	},
-/obj/effect/decal/cleanable/dirt/visible,
-/turf/unsimulated/floor/freezer,
-/area/map_template/summit{
-	germ_level = 800000000;
-	temperature = 0
-	})
 "pK" = (
 /obj/machinery/igniter{
 	id_tag = "selfd";
@@ -3207,12 +3144,6 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/mob/living/simple_animal/aggressive/avianborg{
-	glowing_eyes = 1;
-	attack_delay = 15;
-	base_movement_delay = 5;
-	mob_size = 15
-	},
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib2"
 	},
@@ -3248,7 +3179,7 @@
 /mob/living/simple_animal/aggressive/humborg{
 	glowing_eyes = 1;
 	attack_delay = 30;
-	base_movement_delay = 5
+	base_movement_delay = 10
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/reinforced/oxygen{
@@ -3438,12 +3369,6 @@
 	temperature = 0
 	})
 "tr" = (
-/mob/living/simple_animal/aggressive/avianborg{
-	glowing_eyes = 1;
-	attack_delay = 15;
-	base_movement_delay = 5;
-	mob_size = 15
-	},
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib1"
 	},
@@ -3902,6 +3827,10 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	dir = 8;
+	pixel_x = 45
+	},
 /turf/floor/greengrid,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -4103,6 +4032,9 @@
 	valve_open = 1;
 	release_pressure = 1000
 	},
+/obj/structure/sign/warning/radioactive/alt{
+	pixel_y = 38
+	},
 /turf/floor/reinforced/oxygen{
 	open_turf_type = /turf/open;
 	temperature = 0
@@ -4126,6 +4058,9 @@
 	id_tag = "TRD4";
 	name = "Unlabeled Switch";
 	pixel_y = 26
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
 	},
 /turf/unsimulated/floor/freezer,
 /area/map_template/summit{
@@ -4175,32 +4110,6 @@
 	germ_level = 800000000;
 	temperature = 0
 	})
-"xA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
-	},
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
-	},
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/greengrid,
-/area/map_template/summit{
-	germ_level = 800000000;
-	temperature = 0
-	})
 "xP" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "dir_splatter_2";
@@ -4229,18 +4138,14 @@
 	temperature = 0
 	})
 "yp" = (
-/mob/living/simple_animal/aggressive/avianborg{
-	glowing_eyes = 1;
-	attack_delay = 15;
-	base_movement_delay = 5;
-	mob_size = 15
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/constructable_frame,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib1"
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/cult,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/greengrid,
 /area/map_template/summit{
 	germ_level = 800000000;
 	temperature = 0
@@ -4440,6 +4345,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/dark,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -4474,6 +4382,9 @@
 /obj/machinery/portable_atmospherics/canister/oxygen{
 	valve_open = 1;
 	release_pressure = 1000
+	},
+/obj/structure/sign/warning/radioactive/alt{
+	pixel_y = 38
 	},
 /turf/floor/reinforced/oxygen{
 	open_turf_type = /turf/open;
@@ -4815,23 +4726,21 @@
 	germ_level = 800000000
 	})
 "Es" = (
-/mob/living/simple_animal/aggressive/yingborg{
-	glowing_eyes = 1;
-	attack_delay = 20;
-	mob_size = 10
-	},
+/obj/effect/wallframe_spawn/reinforced_borosilicate,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "mouse"
+/obj/machinery/door/blast/regular{
+	id_tag = "summitsingblast";
+	name = "Singularity Chamber Blast Door";
+	dir = 8
 	},
-/obj/item/remains/mouse{
-	desc = "The tiny remains of a helpless mouse."
+/obj/structure/sign/warning/radioactive/alt{
+	pixel_y = 38
 	},
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/cult,
+/turf/floor/reinforced/oxygen{
+	open_turf_type = /turf/open
+	},
 /area/map_template/summit{
 	germ_level = 800000000;
 	temperature = 0
@@ -5022,6 +4931,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/dark,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -5252,6 +5164,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/dark,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -6615,10 +6530,6 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "u_guilty_l"
 	},
-/obj/structure/barricade/spike{
-	dir = 4;
-	material = /decl/material/solid/metal/steel
-	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/cult,
@@ -7435,10 +7346,6 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "gib2"
 	},
-/obj/structure/barricade/spike{
-	dir = 1;
-	material = /decl/material/solid/metal/steel
-	},
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/decal/cleanable/dirt/visible,
@@ -7630,16 +7537,11 @@
 	temperature = 0
 	})
 "Yi" = (
-/mob/living/simple_animal/aggressive/avianborg{
-	glowing_eyes = 1;
-	attack_delay = 15;
-	base_movement_delay = 5;
-	mob_size = 15
-	},
+/obj/machinery/constructable_frame,
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/reinforced/oxygen{
-	open_turf_type = /turf/open
-	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/greengrid,
 /area/map_template/summit{
 	germ_level = 800000000;
 	temperature = 0
@@ -7737,6 +7639,9 @@
 	pixel_y = 26
 	},
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/sign/warning/secure_area{
+	pixel_y = 38
+	},
 /turf/unsimulated/floor/freezer,
 /area/map_template/summit{
 	germ_level = 800000000;
@@ -8031,7 +7936,7 @@ Hg
 KB
 KB
 KB
-Es
+KB
 sF
 ae
 CS
@@ -8115,7 +8020,7 @@ Xl
 TP
 lt
 rV
-lS
+Yi
 zm
 lS
 ID
@@ -8193,7 +8098,7 @@ Uf
 mF
 br
 Wx
-lS
+Yi
 eA
 Qv
 Zv
@@ -8268,7 +8173,7 @@ DY
 Nq
 rV
 lS
-br
+yp
 Mu
 PC
 Qv
@@ -8330,7 +8235,7 @@ rV
 tG
 DK
 lF
-pJ
+lF
 lF
 TJ
 XI
@@ -8344,7 +8249,7 @@ vt
 Nq
 ik
 rV
-lS
+Yi
 Xe
 lS
 eJ
@@ -8409,7 +8314,7 @@ Ar
 xu
 kb
 uC
-RL
+Es
 KH
 RL
 UJ
@@ -8422,7 +8327,7 @@ Nq
 rV
 lS
 vW
-lS
+Yi
 eA
 Qv
 Zv
@@ -8461,7 +8366,7 @@ rV
 uz
 NN
 hU
-xA
+PC
 Qv
 Zv
 oP
@@ -8549,7 +8454,7 @@ aa
 XR
 XR
 rV
-Yi
+KP
 iK
 mM
 kH
@@ -8675,7 +8580,7 @@ Ar
 xu
 pv
 NX
-RL
+Es
 hu
 RL
 qM
@@ -8762,7 +8667,7 @@ SR
 ZC
 ia
 rV
-br
+yp
 Xe
 lS
 jw
@@ -8878,7 +8783,7 @@ PR
 ID
 qF
 ID
-wy
+dY
 Qv
 Zv
 Cg
@@ -8901,7 +8806,7 @@ cu
 Vm
 co
 XY
-dL
+dU
 Kk
 dn
 Kk
@@ -8951,7 +8856,7 @@ ia
 yy
 La
 rV
-br
+yp
 cz
 lS
 PY
@@ -8991,7 +8896,7 @@ lt
 rV
 br
 GW
-lS
+Yi
 ws
 mF
 rV
@@ -9047,7 +8952,7 @@ XR
 rV
 rV
 fT
-yp
+KB
 zF
 hH
 IS


### PR DESCRIPTION
- Reduced the number of Proselytizing Corporatists by 1/2 on the Overrun Colony (Hateville) map.
- Reduced overall number of mobs from 38 to 23 on the Summit map.