### PR TITLE
Yingages

### DIFF
--- a/mods/valsalia/items/prosthetics.dm
+++ b/mods/valsalia/items/prosthetics.dm
@@ -44,6 +44,12 @@
 	icon_base = 'mods/valsalia/icons/metal_female.dmi'
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_UNDERWEAR
 	uid = "bodytype_prosthetic_yinglet_fbp_fem"
+	age_descriptor = /datum/appearance_descriptor/age/yinglet
+	appearance_descriptors = list(
+		/datum/appearance_descriptor/height = 0.5,
+		/datum/appearance_descriptor/build =  0.5
+	)
+
 
 /decl/bodytype/prosthetic/ying/metal/fbp/masculine
 	name = "yinglet, android"

--- a/mods/valsalia/species/yinglet.dm
+++ b/mods/valsalia/species/yinglet.dm
@@ -85,11 +85,11 @@
 
 /decl/species/yinglet/skills_from_age(age)
 	switch(age)
-		if(0 to 5)
-			. = -4
-		if(5 to 10)
+		if(0 to 2)
+			. = -2
+		if(3 to 7)
 			. = 0
-		if(10 to 15)
+		if(8 to 14)
 			. = 4
 		else
 			. = 8

--- a/mods/valsalia/species/yinglet_bodytype.dm
+++ b/mods/valsalia/species/yinglet_bodytype.dm
@@ -78,9 +78,9 @@
 	chargen_max_index = 5
 	standalone_value_descriptors = list(
 		"a hatchling" =     1,
-		"an younglet" =     3,
-		"an adult" =        6,
-		"middle-aged" =    15,
+		"a juvenile" =     2,
+		"an adult" =        3,
+		"middle-aged" =    13,
 		"aging" =          25,
 		"elderly" =        30
 	)


### PR DESCRIPTION
## Description of changes
Modified yinglet age ranges to better match the canon ages for yinglets
Modified synthetic yinglets to use yinglet ages instead of the default human ones

## Why and what will this PR improve
Better canon-accuracy and character customization
More consistency

## Changelog
:cl:
tweak: changed yinglet age ranges
tweak: synth yings now use yinglet age ranges
tweak: synth yings now use yinglet height descriptors
/:cl: