### PR TITLE
Standardize ministation cargo tech access

### DIFF
--- a/maps/ministation/jobs/civilian.dm
+++ b/maps/ministation/jobs/civilian.dm
@@ -67,6 +67,7 @@
 		access_cargo_bot,
 		access_mining,
 		access_mailsorting,
+		access_eva,
 		access_mining,
 		access_mining_station,
 		access_external_airlocks,
@@ -80,7 +81,8 @@
 		access_eva,
 		access_mining,
 		access_mining_station,
-		access_external_airlocks
+		access_external_airlocks,
+		access_maint_tunnels
 	)
 	min_skill = list(
 		SKILL_FINANCE	= SKILL_BASIC,


### PR DESCRIPTION

## Description of changes
Standardizes the cargo access to always include both maint and EVA.

## Why and what will this PR improve
The access was a little borked considering the minimal version had more access than the normal one. Devcord confirmed this on discord.

## Authorship
Tabski

## Changelog
:cl:
tweak: Ministation cargo technicians will now always have access to maint and EVA
/:cl: