### PR TITLE
Overhauls to Medical, Enclave, and Cargo Hold

### DIFF
--- a/maps/tradeship_alt/tradeship-0.dmm
+++ b/maps/tradeship_alt/tradeship-0.dmm
@@ -40,9 +40,17 @@
 /area/ship/trade/enclave)
 "ae" = (
 /obj/effect/decal/cleanable/generic,
-/obj/item/stool/wood,
 /obj/abstract/landmark/start{
 	name = "Enclave Patriarch"
+	},
+/obj/effect/floor_decal/carpet/green{
+	dir = 9;
+	pixel_x = 25;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/floor/wood/walnut,
 /area/ship/trade/enclave)
@@ -74,20 +82,15 @@
 /turf/floor/plating/airless,
 /area/space)
 "aj" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/autoset,
-/turf/floor/plating,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "ak" = (
-/turf/floor,
+/turf/floor/wood/broken/one,
 /area/ship/trade/fore_port_underside_maint)
 "al" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -117,7 +120,7 @@
 	icon_state = "warning"
 	},
 /obj/structure/closet/crate,
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "ap" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -143,6 +146,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/corner/beige,
 /turf/floor/tiled,
 /area/ship/trade/enclave)
 "ar" = (
@@ -179,7 +183,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "av" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -209,10 +213,9 @@
 	id_tag = "lower_cargo";
 	pixel_y = -18
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "ax" = (
-/obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -220,7 +223,12 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Patriarch"
 	},
-/turf/floor/tiled,
+/obj/effect/floor_decal/carpet/green{
+	dir = 10;
+	pixel_x = 25;
+	pixel_y = 25
+	},
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "ay" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -249,7 +257,10 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Scout"
 	},
-/turf/floor/tiled,
+/obj/effect/floor_decal/carpet/green{
+	pixel_y = 25
+	},
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "aA" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -324,9 +335,6 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/floor,
 /area/ship/trade/loading_bay)
 "aG" = (
@@ -347,7 +355,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -434,7 +442,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -444,12 +452,7 @@
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "aS" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor/autoset,
 /turf/floor/plating,
 /area/ship/trade/fore_port_underside_maint)
@@ -470,12 +473,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
+	},
 /turf/floor/tiled,
 /area/ship/trade/enclave)
 "aU" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor/autoset,
-/turf/floor,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/fore_port_underside_maint)
 "aV" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -563,9 +569,6 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/floor,
 /area/ship/trade/loading_bay)
 "bc" = (
@@ -612,7 +615,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/ladder,
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -628,7 +631,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -646,29 +649,30 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "bk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/table,
 /obj/item/paicard,
-/turf/floor,
+/obj/structure/table/gamblingtable,
+/turf/floor/carpet/green,
 /area/ship/trade/enclave)
 "bl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/item/trash/mollusc_shell/clam,
-/turf/floor,
+/obj/structure/table/gamblingtable,
+/obj/item/mollusc,
+/turf/floor/carpet/green,
 /area/ship/trade/enclave)
 "bo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "bp" = (
 /turf/floor/tiled/techfloor/grid,
@@ -687,7 +691,7 @@
 /area/ship/trade/loading_bay)
 "bs" = (
 /obj/item/tool/axe/hatchet,
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "bu" = (
 /obj/machinery/door/window/brigdoor/northright,
@@ -715,7 +719,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "bz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -727,7 +731,7 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Worker"
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -745,6 +749,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
+/obj/structure/sign/department/janitor,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "bC" = (
@@ -753,7 +758,7 @@
 	},
 /obj/machinery/light,
 /mob/living/simple_animal/passive/mouse/snaprat,
-/turf/floor,
+/turf/floor/wood/broken/three,
 /area/ship/trade/fore_port_underside_maint)
 "bD" = (
 /obj/machinery/power/apc{
@@ -769,7 +774,7 @@
 	name = "shank"
 	},
 /obj/item/synthesized_instrument/synthesizer,
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "bE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -806,24 +811,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/wood/broken/two,
 /area/ship/trade/fore_port_underside_maint)
 "bJ" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/roller/ironingboard,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
 "bK" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/random/mre/sauce/crayon,
-/turf/floor,
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -857,7 +859,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -869,7 +871,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bR" = (
 /obj/structure/cable{
@@ -885,17 +887,16 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "bS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/floor,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
 "bT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -907,17 +908,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "bU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/random/trash,
-/obj/item/grooming/comb/colorable/random,
-/obj/random/tech_supply,
-/obj/random/single/textbook,
-/turf/floor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
 "bV" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -949,17 +949,9 @@
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "bX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "bY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -973,7 +965,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "bZ" = (
 /obj/machinery/power/apc{
@@ -996,20 +988,37 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "ca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -22
 	},
-/turf/floor,
+/obj/structure/closet/l3closet/janitor,
+/obj/item/plunger,
+/obj/item/clothing/gloves/thick,
+/obj/item/paint_sprayer,
+/obj/item/chems/glass/bucket,
+/obj/item/mop,
+/obj/item/assembly/mousetrap,
+/obj/item/assembly/mousetrap,
+/obj/item/radio,
+/obj/item/bag/trash,
+/obj/item/chems/glass/rag,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "cb" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/closet/crate/hydroponics/beekeeping,
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "cc" = (
 /obj/machinery/light{
@@ -1022,7 +1031,6 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Worker"
 	},
-/obj/structure/window/reinforced,
 /turf/floor,
 /area/ship/trade/loading_bay)
 "cd" = (
@@ -1030,12 +1038,12 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/structure/window/reinforced,
 /turf/floor,
 /area/ship/trade/loading_bay)
 "cr" = (
-/obj/item/tool/hoe/mini,
-/turf/floor,
+/obj/structure/table/steel,
+/obj/item/toy/figure/janitor,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "cX" = (
 /obj/machinery/alarm{
@@ -1055,12 +1063,34 @@
 	},
 /turf/floor/tiled,
 /area/ship/trade/enclave)
-"dN" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/item/tool/hoe/mini,
-/turf/floor/plating/dirt,
+"ds" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/honey_extractor,
+/obj/item/seeds/tomatoseed,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
+"dN" = (
+/turf/unsimulated/dark_filler,
+/area/space)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "en" = (
+/obj/effect/floor_decal/carpet/green{
+	dir = 5;
+	pixel_x = -25;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "eu" = (
@@ -1072,34 +1102,39 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
-/turf/floor/tiled,
+/turf/floor/wood/walnut,
 /area/ship/trade/loading_bay)
 "fp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/suit_cycler/tradeship,
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "fB" = (
 /obj/structure/yinglet_nest,
 /turf/floor/carpet/red,
 /area/ship/trade/enclave)
+"fR" = (
+/obj/structure/bookcase/ebony,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "fV" = (
-/obj/item/mollusc,
-/obj/item/mollusc/barnacle,
-/obj/item/mollusc/clam,
-/obj/structure/table/gamblingtable,
-/turf/floor/carpet/red,
+/obj/item/stool/padded,
+/obj/effect/floor_decal/carpet/green{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1126,13 +1161,46 @@
 /obj/structure/junkpile/mapped,
 /turf/floor/carpet/green,
 /area/ship/trade/enclave)
+"gp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
+"gw" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	level = 2
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
+"gQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
 "hc" = (
-/obj/item/radio,
-/obj/structure/table/woodentable/walnut,
-/turf/floor/wood/walnut,
-/area/ship/trade/enclave)
+/turf/wall/r_wall/hull,
+/area/ship/trade/unused)
 "hf" = (
-/obj/structure/lattice,
 /obj/machinery/light/small,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1145,7 +1213,12 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "hF" = (
-/turf/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "hZ" = (
 /obj/machinery/conveyor{
@@ -1165,19 +1238,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor/tiled,
+/obj/effect/floor_decal/carpet/green{
+	pixel_y = 25
+	},
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "iD" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/suit/rubber,
-/obj/structure/window/reinforced,
+/obj/item/clothing/mask/rubber/turner,
 /turf/floor,
 /area/ship/trade/loading_bay)
 "iY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/floor/wood/walnut,
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/floor/tiled,
 /area/ship/trade/enclave)
 "jk" = (
 /obj/item/mollusc/barnacle{
@@ -1186,6 +1268,10 @@
 	},
 /turf/floor/plating/airless,
 /area/ship/trade/livestock)
+"jB" = (
+/obj/structure/loot_pile/bookcase/ebony,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "jT" = (
 /turf/floor/plating/airless,
 /area/ship/trade/livestock)
@@ -1194,12 +1280,7 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "kO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "kS" = (
 /obj/machinery/conveyor{
@@ -1209,14 +1290,14 @@
 /obj/random/trash,
 /turf/floor,
 /area/ship/trade/loading_bay)
+"lc" = (
+/obj/structure/loot_pile/maint/trash,
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
 "lg" = (
-/obj/item/stool/bar/padded,
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1224,8 +1305,28 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Patriarch"
 	},
-/turf/floor/tiled,
+/obj/effect/floor_decal/carpet/green{
+	dir = 6;
+	pixel_y = 25;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
+"lr" = (
+/obj/effect/paint/brown,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor/autoset,
+/turf/floor/plating,
+/area/ship/trade/fore_port_underside_maint)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1236,8 +1337,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/floor/plating/dirt,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "lv" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1260,13 +1360,27 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/space,
 /area/space)
-"ne" = (
+"mI" = (
+/obj/structure/lattice,
+/turf/wall,
+/area/ship/trade/aft_starboard_underside_maint)
+"mQ" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor,
+/obj/machinery/door/firedoor,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/loading_bay)
+"nb" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/mob/living/simple_animal/passive/ivenmoth/yellow/Binny,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
+"ne" = (
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "nz" = (
 /obj/machinery/door/blast/regular{
@@ -1277,33 +1391,37 @@
 /turf/floor,
 /area/ship/trade/livestock)
 "nE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
 	},
-/obj/random/trash,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor,
+/obj/machinery/door/firedoor/autoset,
+/obj/machinery/door/firedoor/autoset,
+/turf/floor/plating,
 /area/ship/trade/fore_port_underside_maint)
 "oo" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/floor/plating/dirt,
+/obj/structure/table/steel,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "or" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/floor/plating/dirt,
 /area/ship/trade/aft_port_underside_maint)
 "os" = (
-/obj/structure/lattice,
-/obj/item/mollusc/barnacle{
-	pixel_x = 9;
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/floor/plating/airless,
-/area/space)
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/floor/plating/dirt,
+/area/ship/trade/aft_port_underside_maint)
 "oG" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
@@ -1314,14 +1432,16 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/enclave)
+"oJ" = (
+/obj/effect/decal/cleanable/filth,
+/turf/floor/plating,
+/area/ship/trade/aft_starboard_underside_maint)
 "oO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
+	dir = 8;
 	level = 2
 	},
-/obj/item/wrench,
-/obj/random/tool,
-/turf/floor,
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
 "oP" = (
 /obj/effect/paint/brown,
@@ -1346,6 +1466,19 @@
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
+"pv" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/autoset,
+/turf/floor/plating,
+/area/ship/trade/fore_port_underside_maint)
 "pG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -1353,7 +1486,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/floor/tiled,
+/obj/structure/table/gamblingtable,
+/obj/item/radio,
+/turf/floor/carpet/green,
 /area/ship/trade/enclave)
 "pU" = (
 /obj/structure/window/basic,
@@ -1361,11 +1496,17 @@
 	icon_state = "closed";
 	opacity = 1
 	},
-/turf/floor/plating,
+/turf/floor/wood/walnut,
 /area/ship/trade/loading_bay)
 "qt" = (
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/tiled,
+/obj/item/stool/padded,
+/obj/effect/floor_decal/carpet/green{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "qK" = (
 /obj/effect/paint/brown,
@@ -1393,11 +1534,11 @@
 /turf/floor/tiled,
 /area/ship/trade/enclave)
 "rt" = (
-/obj/structure/bed/chair/padded/beige,
 /obj/abstract/landmark/start{
 	name = "Enclave Matriarch"
 	},
-/turf/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "rv" = (
 /obj/item/radio/intercom{
@@ -1426,13 +1567,49 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
+"rP" = (
+/obj/effect/paint/brown,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/floor/plating,
+/area/ship/trade/aft_port_underside_maint)
 "rX" = (
 /obj/structure/yinglet_nest,
 /turf/floor/carpet/green,
 /area/ship/trade/enclave)
+"rZ" = (
+/obj/structure/table/steel,
+/obj/item/belt/janitor,
+/obj/item/soap/crafted,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
+"sd" = (
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
 "sO" = (
 /turf/floor,
 /area/ship/trade/loading_bay)
+"sP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/floor/fake_grass,
+/area/ship/trade/aft_port_underside_maint)
 "sX" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1445,13 +1622,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/livestock)
 "tt" = (
 /obj/abstract/landmark/start{
 	name = "Enclave Scout"
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "tD" = (
 /obj/structure/cable{
@@ -1468,6 +1645,41 @@
 	},
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
+"tL" = (
+/obj/effect/paint/brown,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor/autoset,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/floor/plating,
+/area/ship/trade/aft_port_underside_maint)
+"tY" = (
+/obj/effect/paint/brown,
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/floor/plating,
+/area/ship/trade/aft_starboard_underside_maint)
 "ug" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -1478,13 +1690,17 @@
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "un" = (
-/obj/structure/janitorialcart,
-/obj/item/box/water{
-	pixel_x = -10;
-	pixel_y = -5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/obj/random/trash,
+/obj/structure/mattress,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
 "ux" = (
 /obj/structure/lattice,
 /obj/effect/paint/brown,
@@ -1500,11 +1716,22 @@
 	pixel_x = 30;
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
+"vK" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "vP" = (
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
+"wo" = (
+/obj/structure/table/steel,
+/obj/item/clothing/suit/jacket/winter/yinglet/janitor,
+/obj/item/clothing/suit/jacket/winter/yinglet/janitor,
+/obj/item/chems/spray/cleaner,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
 "wG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1534,6 +1761,10 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
+"wT" = (
+/obj/structure/mattress/dirty,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
 "xc" = (
 /obj/effect/paint/brown,
 /turf/wall,
@@ -1545,15 +1776,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
+"xx" = (
+/obj/structure/table/desk/dresser,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
 "xy" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/floor/plating/dirt,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
+"xC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "xP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1567,32 +1806,18 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
-"xZ" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -22
-	},
+"xU" = (
+/obj/structure/door/mahogany,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/structure/closet/l3closet/janitor,
-/obj/item/plunger,
-/obj/item/sutures,
-/obj/item/clothing/gloves/thick,
-/obj/item/paint_sprayer,
-/obj/item/chems/glass/bucket,
-/obj/item/mop,
-/obj/item/box/lights/mixed,
-/obj/item/assembly/mousetrap,
-/obj/item/assembly/mousetrap,
-/obj/item/radio,
-/obj/item/bag/trash,
-/obj/item/chems/glass/rag,
-/obj/item/caution,
-/obj/item/caution,
-/obj/item/caution,
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/turf/floor/wood/mahogany,
+/area/ship/trade/enclave)
+"xZ" = (
+/obj/random/trash,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "yr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1613,17 +1838,8 @@
 /turf/floor/tiled,
 /area/ship/trade/enclave)
 "yE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "yO" = (
 /turf/wall,
 /area/ship/trade/loading_bay)
@@ -1631,10 +1847,12 @@
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/loading_bay)
 "yT" = (
-/obj/machinery/honey_extractor,
-/obj/item/seeds/tomatoseed,
-/turf/floor,
-/area/ship/trade/aft_port_underside_maint)
+/obj/structure/loot_pile/bookcase/ebony,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "zb" = (
 /turf/wall,
 /area/ship/trade/livestock)
@@ -1644,9 +1862,34 @@
 	icon_state = "warning"
 	},
 /obj/random/trash,
-/obj/structure/window/reinforced,
 /turf/floor,
 /area/ship/trade/loading_bay)
+"zm" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/item/chems/glass/bottle/eznutrient,
+/obj/item/chems/glass/bottle/eznutrient,
+/obj/item/seeds/tomatoseed,
+/obj/item/seeds/tomatoseed,
+/obj/structure/table,
+/obj/item/box/water{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/tool/hoe/mini,
+/turf/floor/fake_grass,
+/area/ship/trade/aft_port_underside_maint)
+"Ac" = (
+/obj/structure/bookcase/cart,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/random/trash,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "AG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -1657,9 +1900,11 @@
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
 "AO" = (
-/obj/structure/hygiene/drain,
-/mob/living/simple_animal/passive/mouse/snaprat,
-/turf/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "AT" = (
 /turf/floor/carpet/green,
@@ -1672,23 +1917,45 @@
 /obj/effect/paint/brown,
 /turf/wall,
 /area/ship/trade/fore_port_underside_maint)
-"Cg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/random/trash,
-/obj/structure/mattress,
+"BB" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/floor,
-/area/ship/trade/fore_port_underside_maint)
-"Ck" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -22
+	},
+/turf/floor/plating/dirt,
+/area/ship/trade/aft_port_underside_maint)
+"BU" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
+"Cd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
+"Cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/floor,
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
+"Ck" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/loot_pile/maint/trash,
+/turf/floor/wood/broken,
 /area/ship/trade/fore_port_underside_maint)
 "Dt" = (
 /obj/abstract/level_data_spawner/main_level{
@@ -1708,7 +1975,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "DT" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -1718,15 +1985,18 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/undercomms)
 "DV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/tiled,
+/obj/item/stool/padded,
+/obj/effect/floor_decal/carpet/green{
+	dir = 8;
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "Ff" = (
 /obj/structure/flora/pottedplant/bamboo,
@@ -1754,16 +2024,21 @@
 /turf/wall/r_wall/hull,
 /area/ship/trade/fore_port_underside_maint)
 "Gp" = (
-/obj/structure/table,
-/obj/item/coin/iron{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/gloves/bracelet,
-/obj/random/lipstick,
-/obj/random/coin,
-/turf/floor,
+/obj/structure/table/steel,
+/obj/item/box/lights,
+/obj/item/lightreplacer,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
+"GE" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/autoset,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/fore_port_underside_maint)
 "GH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1815,22 +2090,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_cycler/tradeship,
-/turf/floor,
+/obj/structure/loot_pile/maint/trash,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
-"Iq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"Ih" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/suit_cycler/tradeship,
-/turf/floor,
-/area/ship/trade/fore_port_underside_maint)
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "Iu" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
@@ -1842,6 +2111,12 @@
 /obj/effect/paint/brown,
 /turf/wall/r_wall/hull,
 /area/ship/trade/livestock)
+"IF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/floor/tiled/techfloor/grid,
+/area/ship/trade/aft_starboard_underside_maint)
 "IG" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 1
@@ -1874,7 +2149,7 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "JI" = (
 /turf/floor/tiled,
@@ -1894,23 +2169,16 @@
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "KO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/random/voidsuit,
-/obj/random/voidhelmet,
-/obj/structure/closet/emcloset,
-/obj/random/voidsuit,
-/obj/random/voidhelmet,
-/turf/floor,
-/area/ship/trade/aft_starboard_underside_maint)
+/obj/structure/bookcase/ebony,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "KZ" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/floor,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/loading_bay)
 "Lm" = (
 /obj/effect/paint/brown,
@@ -1927,23 +2195,24 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
+"LA" = (
+/obj/structure/loot_pile/bookcase/ebony,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "LB" = (
-/obj/structure/lattice,
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
 /obj/structure/curtain/open/bed,
 /turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "LH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/roller/ironingboard,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor,
+/turf/floor/wood/broken,
 /area/ship/trade/fore_port_underside_maint)
 "LI" = (
 /obj/structure/cable{
@@ -1976,9 +2245,12 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Worker"
 	},
-/obj/structure/window/reinforced,
 /turf/floor,
 /area/ship/trade/loading_bay)
+"LU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/wood/walnut,
+/area/ship/trade/enclave)
 "Mb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm{
@@ -2023,7 +2295,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "MY" = (
 /obj/structure/cable{
@@ -2035,6 +2307,17 @@
 	},
 /turf/floor/tiled/white,
 /area/ship/trade/livestock)
+"Nm" = (
+/obj/structure/bookcase/ebony,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -22
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "Nq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2045,13 +2328,24 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
 "NR" = (
 /obj/structure/mattress,
 /obj/item/trash/mollusc_shell,
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
+"OA" = (
+/obj/structure/door/mahogany,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/wood/mahogany,
+/area/ship/trade/enclave)
+"OO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/random/trash,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "OY" = (
 /obj/structure/junkpile/mapped,
 /obj/item/clothing/head/helmet/space/void/yinglet/matriarch,
@@ -2063,7 +2357,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/floor,
+/obj/structure/table/gamblingtable,
+/obj/item/mollusc/clam,
+/obj/item/mollusc/barnacle,
+/turf/floor/carpet/green,
 /area/ship/trade/enclave)
 "PF" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2073,17 +2370,18 @@
 /turf/floor/tiled,
 /area/ship/trade/loading_bay)
 "PZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
+/obj/effect/decal/cleanable/filth,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/random/toy,
-/turf/floor,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "Qh" = (
 /obj/structure/table/woodentable/mahogany,
@@ -2106,7 +2404,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/floor/tiled/steel_grid,
+/turf/floor/plating,
 /area/ship/trade/loading_bay)
 "Qy" = (
 /obj/abstract/turbolift_spawner/tradeship{
@@ -2116,11 +2414,10 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "QQ" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/bed/chair/rounded{
+	dir = 1
 	},
-/turf/floor/plating/dirt,
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
 "QW" = (
 /obj/item/stack/tile/floor/five,
@@ -2130,22 +2427,26 @@
 /obj/abstract/landmark/start{
 	name = "Enclave Patriarch"
 	},
-/turf/floor,
-/area/ship/trade/enclave)
-"Ss" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm{
+/obj/effect/floor_decal/carpet/green{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -25
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/wood/walnut,
+/area/ship/trade/enclave)
+"Rg" = (
+/turf/wall,
+/area/ship/trade/aft_port_underside_maint)
+"Ss" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor,
+/turf/floor/wood,
 /area/ship/trade/fore_port_underside_maint)
+"Sw" = (
+/obj/structure/bookcase/manuals,
+/turf/floor/wood/mahogany,
+/area/ship/trade/unused)
 "SC" = (
 /obj/effect/paint/brown,
 /turf/wall/r_wall/hull,
@@ -2158,6 +2459,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/floor/plating,
 /area/ship/trade/loading_bay)
 "SS" = (
@@ -2165,22 +2467,49 @@
 	pixel_y = 20
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor,
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/turf/floor/tiled,
 /area/ship/trade/enclave)
+"ST" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/floor/plating,
+/area/ship/trade/aft_port_underside_maint)
 "TA" = (
 /obj/machinery/light,
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/livestock)
 "Ua" = (
-/obj/structure/bed/chair/wood/walnut,
-/obj/abstract/landmark/start{
-	name = "Enclave Matriarch"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/floor/carpet/red,
-/area/ship/trade/enclave)
+/obj/structure/closet/crate/hydroponics/beekeeping{
+	dir = 4
+	},
+/turf/floor/fake_grass,
+/area/ship/trade/aft_port_underside_maint)
 "Ug" = (
 /obj/structure/curtain/medical,
 /turf/floor,
+/area/ship/trade/enclave)
+"Ux" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/wood/walnut,
 /area/ship/trade/enclave)
 "UI" = (
 /obj/structure/disposaloutlet{
@@ -2191,16 +2520,50 @@
 	},
 /turf/floor,
 /area/ship/trade/loading_bay)
+"VM" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/floor/plating/dirt,
+/area/ship/trade/aft_port_underside_maint)
 "VT" = (
 /obj/machinery/hologram/holopad/longrange,
+/obj/item/stool/padded,
+/obj/effect/floor_decal/carpet/green{
+	dir = 8;
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/floor/wood/walnut,
 /area/ship/trade/enclave)
+"WA" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
+	},
+/turf/floor/tiled,
+/area/ship/trade/enclave)
+"WK" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/autoset,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/floor/plating,
+/area/ship/trade/unused)
 "Xe" = (
 /turf/wall,
 /area/ship/trade/fore_port_underside_maint)
 "Xo" = (
 /obj/structure/hygiene/drain,
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "XL" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -2214,7 +2577,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/enclave)
 "Yc" = (
 /obj/effect/paint/brown,
@@ -2234,26 +2597,16 @@
 /turf/floor/carpet/red,
 /area/ship/trade/enclave)
 "YH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/item/clothing/medal/gold,
-/obj/item/clothing/neck/necklace/locket,
-/obj/random_multi/single_item/captains_spare_id,
-/turf/floor,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "YL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/chems/glass/bottle/eznutrient,
-/obj/item/chems/glass/bottle/eznutrient,
-/obj/item/seeds/tomatoseed,
-/obj/item/seeds/tomatoseed,
-/obj/structure/table,
-/turf/floor,
+/turf/floor/fake_grass,
 /area/ship/trade/aft_port_underside_maint)
 "YW" = (
 /obj/machinery/conveyor{
@@ -2265,23 +2618,24 @@
 /turf/floor,
 /area/ship/trade/loading_bay)
 "YZ" = (
-/obj/structure/hygiene/sink/puddle,
-/turf/floor,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/plating,
 /area/ship/trade/aft_starboard_underside_maint)
-"Zz" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -22
-	},
+"Zq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
-/obj/structure/table,
-/obj/item/stack/material/puck/mapped/uranium,
-/obj/item/utensil/knife/plastic,
-/obj/item/clothing/neck/tie/bow/ugly,
-/obj/random/action_figure,
-/turf/floor,
+/obj/random/trash,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/wood,
+/area/ship/trade/fore_port_underside_maint)
+"Zz" = (
+/obj/structure/janitorialcart,
+/turf/floor/tiled/techfloor/grid,
 /area/ship/trade/aft_starboard_underside_maint)
 "ZA" = (
 /obj/structure/disposaloutlet,
@@ -2299,7 +2653,7 @@
 "ZR" = (
 /obj/structure/window/basic,
 /obj/structure/curtain/open/bed,
-/turf/floor/plating,
+/turf/floor/wood/walnut,
 /area/ship/trade/loading_bay)
 
 (1,1,1) = {"
@@ -4636,27 +4990,27 @@ aa
 aa
 aa
 as
+as
+as
 aa
 aa
+as
+Gb
+Bm
+ai
+ai
+ai
+FD
+Bm
+xc
+as
+as
+as
+as
+dN
+as
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+as
 aa
 aa
 aa
@@ -4718,28 +5072,28 @@ aa
 aa
 as
 as
-as
-as
-aa
-aa
-as
+Gb
+Gb
+lr
+pv
+lr
 Gb
 Bm
-ai
-ai
-ai
-FD
 Bm
+nE
+nE
+Bm
+Bm
+xc
+rP
+rP
+rP
+xc
+Rg
+xc
 xc
 as
 as
-as
-as
-as
-aa
-as
-aa
-aa
 aa
 aa
 aa
@@ -4801,26 +5155,26 @@ aa
 aa
 oX
 Gb
-Gb
-Gb
-aj
-Gb
-Gb
-Bm
-Bm
+gQ
 aj
 aj
-Bm
-Bm
-xc
-xc
-xc
-xc
-xc
-xc
-xc
-as
-as
+Ck
+aj
+GE
+gp
+bJ
+un
+Zq
+GE
+YL
+Ua
+ds
+sP
+zm
+kO
+VM
+tL
+ar
 aa
 aa
 aa
@@ -4882,9 +5236,9 @@ aa
 SC
 SC
 SC
-Gb
+Xe
 fp
-ne
+lc
 ne
 ne
 ne
@@ -4892,16 +5246,16 @@ aS
 Ss
 LH
 Cg
-nE
+by
 aS
 kO
 kO
 kO
-bX
-YL
-bJ
-xc
-ar
+ls
+kO
+kO
+or
+ST
 aa
 aa
 aa
@@ -4965,26 +5319,26 @@ SC
 Ff
 OY
 Xe
-Iq
+Nq
 ak
-ak
-ak
-ak
+ne
+lc
+ne
 aU
 bH
-bH
-Ck
+Ss
+Cg
 by
 aU
-or
+kO
 xy
-dN
-yE
+kO
+ls
 bs
-yT
+kO
+or
 aY
 ar
-aa
 aa
 aa
 aa
@@ -5048,7 +5402,7 @@ Qh
 IG
 Xe
 If
-ak
+ne
 yO
 hg
 yO
@@ -5063,10 +5417,10 @@ yO
 yO
 ls
 Xo
-un
+kO
+or
 aY
 ar
-aa
 aa
 aa
 aa
@@ -5130,7 +5484,7 @@ LB
 hf
 Xe
 Nq
-ak
+ne
 al
 af
 UI
@@ -5142,13 +5496,13 @@ bD
 yO
 bG
 bN
-SE
+mQ
 bY
 bT
 cb
+os
 aY
 ar
-aa
 aa
 aa
 aa
@@ -5202,11 +5556,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+hc
+hc
+hc
+hc
+hc
 ux
 lA
 ad
@@ -5227,10 +5581,10 @@ ga
 yO
 yO
 yO
-xZ
+kO
+BB
 xc
 ar
-aa
 aa
 aa
 aa
@@ -5283,12 +5637,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+hc
+hc
+KO
+yT
+fR
+KO
 SC
 SS
 iY
@@ -5365,14 +5719,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-en
+WK
+Ih
+yE
+vK
+OO
+dZ
+xU
+Ux
 ae
 VT
 DV
@@ -5380,7 +5734,7 @@ ax
 pU
 zi
 lB
-ZC
+sO
 sO
 sO
 sO
@@ -5447,22 +5801,22 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+WK
+bX
+Sw
+yE
+Sw
+Cd
 ab
 rt
-hc
+fV
 bk
 pG
 az
 eu
 cd
 kS
-ZC
+sO
 sO
 sO
 sO
@@ -5529,14 +5883,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+WK
+nb
+Sw
+yE
+Sw
+Cd
 ab
-Ua
+rt
 fV
 bl
 Pa
@@ -5544,7 +5898,7 @@ iy
 ZR
 cd
 hZ
-ZC
+sO
 sO
 sO
 sO
@@ -5611,14 +5965,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-ab
-en
+WK
+Ac
+xZ
+gw
+xC
+tJ
+OA
+LU
 en
 QW
 qt
@@ -5626,7 +5980,7 @@ lg
 eu
 iD
 pg
-ZC
+sO
 sO
 sO
 sO
@@ -5693,17 +6047,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+hc
+hc
+jB
+LA
+KO
+Nm
 SC
 rp
 Iu
 oG
-qt
+WA
 aT
 yO
 LO
@@ -5776,11 +6130,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+hc
+hc
+hc
+hc
+hc
 ux
 lA
 Ug
@@ -5802,9 +6156,9 @@ yO
 yO
 yO
 Zz
+ca
 Yc
-os
-aa
+as
 aa
 aa
 aa
@@ -5884,9 +6238,9 @@ SE
 bS
 PZ
 bU
+BU
 aZ
-ar
-aa
+as
 aa
 aa
 aa
@@ -5965,10 +6319,10 @@ yO
 yO
 YH
 AO
-Gp
+YZ
+YH
 aZ
-ar
-aa
+as
 aa
 aa
 aa
@@ -6043,14 +6397,14 @@ bp
 GQ
 bp
 zb
-oo
+Gp
 cr
-ca
+YZ
 hF
 YZ
+YH
 aZ
-ai
-aa
+as
 aa
 aa
 aa
@@ -6127,12 +6481,12 @@ TA
 zb
 oo
 QQ
-KO
+bK
 oO
 bK
+sd
 Yc
-ar
-aa
+as
 aa
 aa
 aa
@@ -6207,14 +6561,14 @@ nz
 nz
 nz
 oP
+rZ
+wo
+oJ
+IF
+xx
+wT
 Yc
-Yc
-Yc
-Yc
-Yc
-Yc
-ar
-aa
+as
 aa
 aa
 aa
@@ -6289,14 +6643,14 @@ jk
 jT
 jk
 oP
+Yc
+tY
+tY
+tY
+Yc
+mI
+mI
 as
-as
-aa
-aa
-as
-as
-as
-aa
 aa
 aa
 aa
@@ -6369,16 +6723,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 as
-aa
+as
+as
+as
+as
+as
+as
+as
+as
+as
 aa
 aa
 aa
@@ -6452,7 +6806,7 @@ aa
 aa
 aa
 aa
-aa
+as
 aa
 aa
 aa

--- a/maps/tradeship_alt/tradeship-1.dmm
+++ b/maps/tradeship_alt/tradeship-1.dmm
@@ -7,7 +7,7 @@
 	pixel_x = -32;
 	dir = 4
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "ac" = (
 /obj/machinery/door/blast/regular{
@@ -155,7 +155,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/floor/plating,
@@ -184,8 +184,9 @@
 /area/ship/trade/maintenance/eva)
 "ax" = (
 /obj/effect/floor_decal/corner/beige,
-/obj/machinery/mining_drill,
-/turf/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "ay" = (
 /obj/machinery/cryopod/lifepod,
@@ -459,7 +460,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "bd" = (
 /obj/effect/floor_decal/corner/beige{
@@ -545,7 +546,7 @@
 	},
 /obj/structure/disposalpipe/up,
 /obj/effect/decal/cleanable/cobweb,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "bj" = (
 /obj/machinery/power/apc{
@@ -678,7 +679,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -709,7 +712,7 @@
 /area/ship/trade/crew/dorms1)
 "bI" = (
 /obj/structure/disposalpipe/segment,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "bJ" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -720,10 +723,12 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "bK" = (
-/turf/floor/tiled/monotile,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "bM" = (
 /obj/structure/cable{
@@ -741,7 +746,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -750,7 +755,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "bQ" = (
 /obj/machinery/alarm{
@@ -791,13 +797,13 @@
 	dir = 4;
 	pixel_x = -34
 	},
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "bU" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "bV" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -829,7 +835,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/emergency_dispenser/east,
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "ca" = (
 /obj/effect/paint/brown,
@@ -871,6 +877,7 @@
 /obj/structure/table,
 /obj/item/integrated_circuit_printer,
 /obj/machinery/cell_charger,
+/obj/item/clothing/glasses/science,
 /turf/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "ce" = (
@@ -916,7 +923,7 @@
 	dir = 1;
 	pixel_y = -21
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "cm" = (
 /turf/wall,
@@ -1019,7 +1026,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1254,33 +1262,34 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/floor/tiled,
-/area/ship/trade/maintenance/lower)
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/floor/tiled/monotile,
+/area/ship/trade/cargo/lower)
 "dm" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/woodentable/ebony,
+/obj/item/box/bodybags,
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
 "do" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/hygiene/sink{
-	pixel_y = 21
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/button/crematorium{
+	pixel_y = 27;
+	pixel_x = 9
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
 "dq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1313,7 +1322,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dt" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1350,51 +1359,36 @@
 /turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "dy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/eastleft{
-	id_tag = "tank";
-	name = "drunk tank"
-	},
+/obj/effect/floor_decal/borderfloorblack/full,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
-"dz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
-"dA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
+"dA" = (
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
 "dB" = (
-/obj/structure/table,
-/obj/random/plushie,
-/obj/item/synthesized_instrument/violin,
-/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 22
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
 "dD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -1420,14 +1414,16 @@
 	icon_state = "1-10"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dJ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
 "dK" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/corner/beige{
@@ -1435,17 +1431,6 @@
 	},
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
-"dL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	level = 2
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -21
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
 "dP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1459,7 +1444,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dS" = (
 /obj/structure/cable{
@@ -1481,7 +1466,7 @@
 	dir = 1;
 	pixel_y = 22
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dT" = (
 /obj/machinery/light{
@@ -1500,7 +1485,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dU" = (
 /obj/structure/disposalpipe/segment{
@@ -1516,7 +1501,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/emergency_dispenser/north,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1531,7 +1516,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dW" = (
 /obj/structure/cable{
@@ -1545,7 +1530,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1560,7 +1545,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "dZ" = (
 /turf/wall,
@@ -1848,9 +1833,9 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/storage)
 "fa" = (
-/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/floor_decal/borderfloorblack/full,
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
 "fb" = (
 /obj/machinery/light,
 /obj/machinery/suit_cycler/tradeship,
@@ -1925,7 +1910,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "hc" = (
 /obj/structure/tank_rack/oxygen,
@@ -1952,7 +1937,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "hn" = (
 /obj/effect/paint/brown,
@@ -1968,6 +1953,24 @@
 /obj/structure/table/marble,
 /turf/floor,
 /area/ship/trade/science/fabricaton)
+"hH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "hI" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/warning{
@@ -1990,7 +1993,7 @@
 /obj/structure/closet/coffin,
 /obj/random/drinkbottle,
 /obj/item/poster,
-/turf/floor/tiled/monotile,
+/turf/floor/tiled/steel_grid,
 /area/ship/trade/cargo/lower)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2001,7 +2004,8 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 4
 	},
-/turf/floor/tiled,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "iH" = (
 /obj/item/toolbox/mechanical{
@@ -2080,12 +2084,7 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 6
 	},
-/obj/structure/table,
-/obj/item/radio,
-/obj/random/clipboard,
-/obj/item/stamp/denied,
-/obj/item/stamp/cargo,
-/obj/item/paper_bin,
+/obj/structure/ore_box,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "kb" = (
@@ -2102,18 +2101,18 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/tiled,
-/area/ship/trade/maintenance/lower)
-"kr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/maintenance/lower)
 "kA" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
 	},
 /turf/floor/tiled,
-/area/ship/trade/maintenance/lower)
+/area/ship/trade/cargo/lower)
 "kP" = (
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
@@ -2162,8 +2161,13 @@
 /turf/floor/reinforced,
 /area/ship/trade/artifact_storage)
 "lE" = (
-/obj/effect/paint/brown,
-/turf/wall/r_wall,
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "lK" = (
 /turf/floor/tiled/steel_grid,
@@ -2221,9 +2225,15 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/escape_star)
 "nf" = (
-/obj/structure/mech_wreckage/powerloader,
-/obj/machinery/mech_recharger,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/radio,
+/obj/random/clipboard,
+/obj/item/stamp/denied,
+/obj/item/stamp/cargo,
+/obj/item/paper_bin,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "ni" = (
@@ -2265,14 +2275,27 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/stack/material/ore/coal{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/ore/coal{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
+"ot" = (
+/obj/structure/emergency_dispenser/east,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "ox" = (
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "oC" = (
 /obj/machinery/conveyor{
@@ -2328,7 +2351,7 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/space,
+/turf/floor/reinforced,
 /area/space)
 "qF" = (
 /obj/structure/window/reinforced{
@@ -2356,14 +2379,12 @@
 	pixel_x = -32;
 	dir = 4
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "rB" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/item/stack/material/ore/iron,
-/obj/item/stack/material/ore/coal{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/mining_drill,
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
 	},
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
@@ -2372,7 +2393,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/floor/tiled,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "rP" = (
 /obj/structure/handrail{
@@ -2383,7 +2406,7 @@
 "rW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "sb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -2391,7 +2414,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/escape_port)
 "se" = (
 /obj/effect/paint/brown,
@@ -2418,20 +2441,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
-"ts" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 22
-	},
-/obj/item/stool/padded,
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
 "tz" = (
 /obj/machinery/material_processing/smeltery,
 /turf/floor/plating,
@@ -2444,7 +2455,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/techstorage)
 "ub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2459,14 +2471,17 @@
 /turf/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "ui" = (
-/obj/structure/closet/crate,
-/obj/item/strangerock,
-/obj/item/fossil,
-/obj/item/fossil/animal,
-/obj/item/fossil/animal,
-/obj/item/fossil/skull,
-/turf/floor/tiled,
-/area/ship/trade/cargo/lower)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "uj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2477,9 +2492,13 @@
 /area/ship/trade/maintenance/techstorage)
 "un" = (
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/machinery/fabricator/industrial,
-/obj/item/stack/material/ingot/mapped/osmium/ten,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/structure/table,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "uo" = (
@@ -2512,8 +2531,15 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
+"uI" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/turf/floor/tiled,
+/area/ship/trade/cargo/lower)
 "uY" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/backpack/dufflebag,
@@ -2546,7 +2572,7 @@
 /area/ship/trade/science/fabricaton)
 "vI" = (
 /obj/structure/emergency_dispenser/east,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "vW" = (
 /obj/effect/paint/brown,
@@ -2587,18 +2613,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/floor/plating,
-/area/ship/trade/maintenance/lower)
-"wI" = (
-/obj/structure/bed/padded,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/bedsheet/mime,
-/obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/maintenance/lower)
+"wI" = (
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/structure/crematorium,
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
 "xa" = (
 /obj/effect/paint/brown,
 /turf/wall,
@@ -2654,7 +2676,9 @@
 	pixel_y = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "yT" = (
 /obj/structure/sign/warning/caution{
@@ -2675,7 +2699,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/science,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/artifact_storage)
 "zC" = (
 /obj/machinery/conveyor{
@@ -2690,16 +2714,24 @@
 "zJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/emergency_dispenser/east,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Ab" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/cargo/lower)
+"Al" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/maintenance/lower)
 "AM" = (
-/turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/obj/effect/floor_decal/sign/m{
+	name = "morgue"
+	},
+/turf/wall/r_wall,
+/area/ship/trade/crew/morgue)
 "Bb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2712,7 +2744,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/floor/tiled/dark,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/dorms1)
 "Bq" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -2724,31 +2756,16 @@
 	},
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
-"BO" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/mime,
-/obj/machinery/light_switch{
-	pixel_y = -20;
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	dir = 4
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
 "Cd" = (
-/obj/effect/paint/brown,
-/turf/wall,
-/area/ship/trade/drunk_tank)
+/turf/wall/r_wall,
+/area/ship/trade/crew/morgue)
 "Cr" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 8
 	},
-/turf/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "CN" = (
 /obj/structure/window/reinforced{
@@ -2793,43 +2810,54 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/floor/tiled,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "DL" = (
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
+"DP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "DQ" = (
 /obj/machinery/door/airlock/hatch/autoname/engineering,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/eva)
-"DV" = (
-/obj/machinery/door_timer/cell_1{
-	id_tag = "tank";
-	name = "Drunk Tank";
-	pixel_x = 32
-	},
-/obj/item/stool/padded,
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
 "DX" = (
-/obj/effect/paint/brown,
-/turf/wall/r_wall,
-/area/ship/trade/drunk_tank)
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/structure/closet/coffin,
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
+"Eb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "Ei" = (
 /turf/floor/plating/airless,
 /area/space)
-"En" = (
-/obj/item/stool/padded,
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
 "Er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "EB" = (
 /obj/structure/cable{
@@ -2838,7 +2866,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "EL" = (
 /obj/item/mollusc/barnacle{
@@ -2857,6 +2886,14 @@
 	},
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
+"FW" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/machinery/fabricator/industrial,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled,
+/area/ship/trade/cargo/lower)
 "Gb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -2952,7 +2989,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/science,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/science/fabricaton)
 "Jl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2960,7 +2998,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Jr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2991,7 +3031,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/floor/tiled/dark,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/dorms2)
 "La" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3003,7 +3043,8 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 8
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Lb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3018,9 +3059,15 @@
 /turf/floor/lino,
 /area/ship/trade/crew/dorms2)
 "Lx" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/item/stool/padded,
-/turf/floor/tiled,
+/obj/structure/closet/crate,
+/obj/item/strangerock,
+/obj/item/fossil,
+/obj/item/fossil/animal,
+/obj/item/fossil/animal,
+/obj/item/fossil/skull,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/floor/tiled/monotile,
 /area/ship/trade/cargo/lower)
 "LE" = (
 /obj/machinery/alarm{
@@ -3038,7 +3085,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/effect/wallframe_spawn/reinforced,
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Ml" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3047,19 +3094,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Mx" = (
 /obj/effect/paint/brown,
 /turf/wall,
 /area/ship/trade/escape_port)
 "Nb" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/structure/table/woodentable/ebony,
+/obj/item/urn,
 /turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/area/ship/trade/crew/morgue)
 "Nc" = (
 /obj/machinery/destructive_analyzer,
 /turf/floor/tiled/white,
@@ -3086,12 +3132,25 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/science,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/science)
 "On" = (
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
+"OS" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/floor/tiled,
+/area/ship/trade/cargo/lower)
 "Pb" = (
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/door/airlock/hatch/autoname/general,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3101,11 +3160,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
+"Ps" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/maintenance/lower)
 "Py" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/structure/disposalpipe/segment/bent{
@@ -3123,7 +3187,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "PJ" = (
 /obj/structure/curtain/open/bed,
@@ -3139,6 +3204,12 @@
 /obj/item/stack/material/ingot/mapped/osmium/ten,
 /turf/floor/lino,
 /area/ship/trade/crew/dorms2)
+"PY" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/maintenance/lower)
 "Qb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
@@ -3146,7 +3217,7 @@
 	pixel_x = 34;
 	dir = 8
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/cargo/lower)
 "Qc" = (
 /obj/structure/cable{
@@ -3200,7 +3271,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/cargo/lower)
 "Rl" = (
 /obj/machinery/material_processing/compressor,
@@ -3230,18 +3301,11 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/eva)
 "Sb" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -21
-	},
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/hygiene/toilet{
-	dir = 1
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/drunk_tank)
+/turf/floor/reinforced,
+/area/space)
 "Sc" = (
-/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled,
 /area/ship/trade/cargo/lower)
 "Sm" = (
@@ -3300,14 +3364,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Tk" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Tp" = (
 /turf/floor/plating/airless,
@@ -3323,7 +3387,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/tiled,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Ub" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -3340,24 +3405,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/lower)
 "UO" = (
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "UX" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/turf/floor/tiled/dark,
+/area/ship/trade/crew/morgue)
 "Va" = (
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
@@ -3377,7 +3440,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/lower)
 "Vc" = (
 /obj/effect/paint/brown,
@@ -3420,8 +3483,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
+"VK" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/corner/beige{
+	dir = 6
+	},
+/turf/floor/tiled,
+/area/ship/trade/cargo/lower)
 "VL" = (
 /obj/machinery/door/blast/regular{
 	dir = 2
@@ -3430,15 +3501,14 @@
 /turf/floor/plating/airless,
 /area/ship/trade/escape_port)
 "VX" = (
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "Wi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/floor/tiled,
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/lower)
 "Wm" = (
 /obj/machinery/network/relay{
@@ -3477,12 +3547,11 @@
 /obj/item/stock_parts/circuitboard/unary_atmos/heater,
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/techstorage)
-"YH" = (
-/turf/wall,
-/area/ship/trade/drunk_tank)
 "Za" = (
-/turf/floor/plating,
-/area/ship/trade/drunk_tank)
+/obj/effect/paint/brown,
+/obj/effect/paint/brown,
+/turf/wall/r_wall,
+/area/ship/trade/cargo/lower)
 "Zb" = (
 /obj/item/toolbox/electrical,
 /obj/item/toolbox/electrical{
@@ -3527,7 +3596,7 @@
 /area/ship/trade/maintenance/storage)
 "ZA" = (
 /obj/structure/emergency_dispenser/west,
-/turf/floor/tiled,
+/turf/floor/tiled/dark,
 /area/ship/trade/maintenance/lower)
 "ZJ" = (
 /turf/wall,
@@ -6203,18 +6272,18 @@ cf
 sb
 bc
 Tc
-On
+VX
 UO
 rA
 On
 Vr
-ap
+Al
 dk
 ab
-Dl
-kA
+ui
+dk
 VX
-On
+VX
 dZ
 rb
 eu
@@ -6286,9 +6355,9 @@ ah
 On
 hf
 Ml
-Wi
+Ml
 it
-TZ
+Eb
 uz
 uo
 TZ
@@ -6353,31 +6422,31 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 ql
 pr
 pr
 al
 al
 al
+pr
+pr
 ah
 ah
 ah
-On
+VX
 br
 zJ
 bI
 ds
 On
 On
-ap
-VX
-VX
+PY
+On
+On
 vI
 dP
-VX
+On
 On
 dZ
 Wm
@@ -6435,15 +6504,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Sb
+Sb
 ad
 aj
 au
 aG
 aF
+OS
+FW
 nf
 un
 ao
@@ -6460,7 +6529,7 @@ Ab
 ao
 Ub
 rW
-uw
+Wi
 dZ
 Zb
 ew
@@ -6517,15 +6586,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+Sb
+Sb
 ae
 ak
 av
 aG
 aS
+du
+uI
 du
 Cr
 aR
@@ -6599,21 +6668,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
-lE
-mh
+Za
+pr
 al
 al
 aH
-aU
 du
+Sc
+du
+dl
 Js
 gb
 bu
-bK
+lK
 bU
 lZ
 lZ
@@ -6623,8 +6692,8 @@ mb
 lK
 ao
 dS
-On
 VX
+On
 ef
 ef
 ey
@@ -6681,14 +6750,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
 dK
+du
+Sc
+du
+du
 aU
-du
-du
 du
 aU
 du
@@ -6705,8 +6774,8 @@ dh
 dv
 ao
 dT
-On
 VX
+On
 eb
 em
 ez
@@ -6763,18 +6832,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
 IU
-Sc
+bK
 Sx
 Sx
 CN
-rB
 du
-ui
+du
+du
+du
+aU
 bf
 bw
 bM
@@ -6845,15 +6914,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
 dK
-Sc
+bK
 he
 he
 lw
+du
+Sc
 aU
 Lx
 Zd
@@ -6869,8 +6938,8 @@ di
 hI
 ao
 dV
-On
-On
+VX
+VX
 ed
 ee
 gc
@@ -6927,14 +6996,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
 Bq
 aU
 tz
 Rl
+aU
+du
 aU
 HH
 ax
@@ -6951,7 +7020,7 @@ dj
 dw
 Rb
 dW
-On
+VX
 On
 DQ
 eo
@@ -7009,15 +7078,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
-IU
-Sc
+kA
+VK
 zC
 oC
 gh
+lE
+rB
 od
 jV
 ao
@@ -7034,7 +7103,7 @@ Ab
 ao
 Vb
 rW
-uw
+Al
 ed
 ep
 eD
@@ -7091,27 +7160,27 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+Sb
 al
 pr
 pr
 pr
 pr
-gX
+mh
+pr
+pr
 ZJ
 ZJ
 ZJ
 bi
 rN
 VX
-On
-On
 VX
 VX
+VX
+On
 ap
-dk
+Ps
 On
 ZA
 dY
@@ -7189,12 +7258,12 @@ EB
 bz
 bP
 yL
-bP
+DP
 cC
 bP
 Mb
-dl
-cC
+bP
+hH
 dH
 La
 VX
@@ -7269,7 +7338,7 @@ iI
 NC
 Tk
 Dl
-vI
+ot
 ox
 Tk
 tq
@@ -7279,7 +7348,7 @@ On
 wG
 VX
 VX
-VX
+On
 On
 ed
 Qg
@@ -7357,12 +7426,12 @@ cm
 Kb
 cm
 cm
-ts
+Cd
 Pb
-Za
-En
-DV
-Za
+AM
+Cd
+Cd
+Cd
 ee
 ed
 aD
@@ -7444,7 +7513,7 @@ dy
 UX
 dJ
 DX
-YH
+Cd
 hn
 Gd
 aI
@@ -7522,11 +7591,11 @@ cF
 Lb
 cm
 Nb
-dz
-AM
-Sb
+dA
+fa
+fa
 DX
-aa
+Cd
 Gd
 Gd
 aJ
@@ -7605,10 +7674,10 @@ cO
 cm
 do
 dA
-kr
-dL
+fa
+fa
 DX
-aa
+Cd
 ee
 Gd
 aL
@@ -7688,9 +7757,9 @@ xa
 wI
 dB
 fa
-BO
+fa
 DX
-aa
+Cd
 aa
 aa
 aa
@@ -7768,11 +7837,11 @@ an
 xa
 cq
 Cd
+Cd
 at
 at
-DX
-DX
-aa
+Cd
+Cd
 aa
 aa
 aa

--- a/maps/tradeship_alt/tradeship-2.dmm
+++ b/maps/tradeship_alt/tradeship-2.dmm
@@ -80,6 +80,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "ai" = (
@@ -120,7 +121,8 @@
 	pixel_x = -22
 	},
 /obj/structure/cable,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "am" = (
 /obj/structure/ladder,
@@ -183,6 +185,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "au" = (
@@ -238,14 +242,18 @@
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "aC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "scraplock";
+	name = "scraplock"
+	},
 /turf/floor/plating,
-/area/ship/trade/crew/hallway/port)
+/area/ship/trade/crew/wash)
 "aD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/hallway/starboard)
 "aE" = (
 /obj/machinery/door/firedoor,
@@ -261,7 +269,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/hallway/port)
 "aG" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -282,12 +290,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/tiled/techmaint,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/hallway/starboard)
 "aI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/hallway)
 "aJ" = (
 /obj/structure/disposalpipe/segment,
@@ -299,7 +307,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/tiled/techmaint,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/hallway)
 "aK" = (
 /obj/machinery/door/firedoor,
@@ -311,7 +320,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/plating,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/hallway)
 "aL" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -331,11 +340,12 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
-/area/ship/trade/unused)
+/area/ship/trade/crew/surgery)
 "aN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/autoname/general,
-/turf/floor/tiled/techmaint,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/hallway)
 "aO" = (
 /obj/random/maintenance,
@@ -387,7 +397,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "aT" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -775,6 +785,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bD" = (
@@ -903,12 +914,14 @@
 /area/ship/trade/shuttle/outgoing/general)
 "bM" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "bN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bO" = (
@@ -927,6 +940,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bU" = (
@@ -1109,6 +1123,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "cY" = (
@@ -1214,7 +1229,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "dn" = (
 /obj/structure/cable{
@@ -1225,6 +1241,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "dr" = (
@@ -1531,6 +1548,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "dP" = (
@@ -1575,6 +1593,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/emergency_dispenser/west,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "dW" = (
@@ -1608,7 +1627,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "eb" = (
 /turf/wall,
@@ -1621,7 +1640,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/floor/tiled,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/cargo)
 "ed" = (
 /obj/machinery/light_switch{
@@ -1634,6 +1653,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "ee" = (
@@ -1643,7 +1664,6 @@
 /turf/wall/natural,
 /area/space)
 "el" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Crew Deck APC";
@@ -1653,10 +1673,18 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
@@ -1681,7 +1709,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "es" = (
 /obj/machinery/sleeper/standard,
@@ -1694,7 +1722,9 @@
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "ev" = (
-/turf/wall/r_wall,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "ew" = (
 /turf/wall/natural/random/high_chance,
@@ -1713,26 +1743,26 @@
 /turf/floor/plating,
 /area/ship/trade/hangout)
 "ez" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/turf/floor/tiled/dark,
-/area/ship/trade/hangout)
+/obj/machinery/light,
+/obj/machinery/body_scan_display{
+	pixel_y = -21;
+	dir = 1
+	},
+/obj/machinery/optable,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "eA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/stool/padded,
-/turf/floor/tiled/dark,
-/area/ship/trade/hangout)
+/obj/machinery/door/airlock/hatch{
+	name = "Chemistry bay";
+	normalspeed = 0;
+	stripe_color = "#ffffff"
+	},
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/crew/medbay)
 "eB" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Galley APC";
-	pixel_x = 22
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/hangout)
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "eC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1740,7 +1770,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "eE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1823,44 +1853,19 @@
 /turf/floor/reinforced/airless,
 /area/ship/trade/maintenance/engine/aft)
 "eP" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "bulb1"
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/hangout)
-"eQ" = (
 /obj/effect/decal/cleanable/dirt/visible,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
+"eQ" = (
+/obj/structure/disposalpipe/segment,
 /turf/floor/tiled/dark,
 /area/ship/trade/hangout)
 "eR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "conpipe-c"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/hangout)
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "eS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1876,23 +1881,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/floor/tiled/steel_ridged,
 /area/ship/trade/hangout)
 "eT" = (
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "eU" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -1917,7 +1917,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "fb" = (
 /obj/structure/cable{
@@ -2221,19 +2221,11 @@
 /turf/wall/r_wall,
 /area/ship/trade/crew/wash)
 "fU" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -21
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/obj/structure/undies_wardrobe,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/floor/tiled/freezer,
-/area/ship/trade/crew/wash)
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "fV" = (
 /obj/structure/bed/chair/office/light,
 /obj/abstract/landmark/start{
@@ -2242,29 +2234,10 @@
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "fX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Laundry";
-	normalspeed = 0;
-	stripe_color = "#b7f27d"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/floor/tiled/steel_ridged,
-/area/ship/trade/crew/wash)
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
 "fY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2299,8 +2272,6 @@
 /turf/open,
 /area/ship/trade/cargo)
 "gc" = (
-/obj/machinery/door/airlock/hatch/autoname/general,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2313,8 +2284,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
-/area/ship/trade/unused)
+/turf/wall,
+/area/ship/trade/crew/surgery)
 "gd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2322,36 +2293,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
-"ge" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -21
+	},
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/obj/random/maintenance,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
+"ge" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/fabricator/book,
-/obj/item/stack/material/panel/mapped/plastic/ten,
-/obj/item/stack/material/plank/mapped/wood/ten,
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "gg" = (
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
-/area/ship/trade/unused)
+/area/ship/trade/crew/surgery)
 "gh" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/paint/red,
@@ -2391,19 +2360,17 @@
 	dir = 4
 	},
 /turf/floor/plating,
-/area/ship/trade/crew/wash)
+/area/ship/trade/hangout)
 "go" = (
-/obj/structure/closet,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "bulb1"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/obj/item/backpack/dufflebag,
-/turf/floor/tiled/freezer,
-/area/ship/trade/crew/wash)
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/floor/tiled/freezer,
@@ -2461,21 +2428,22 @@
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "gu" = (
-/turf/wall,
-/area/ship/trade/unused)
-"gv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular/open{
 	dir = 4;
-	pixel_x = -21
+	id_tag = "scraplock";
+	name = "scraplock"
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
+"gv" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "gw" = (
 /obj/effect/decal/cleanable/generic,
-/obj/structure/skele_stand{
-	name = "Grand Archivist Spookers"
-	},
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
@@ -2483,16 +2451,15 @@
 	dir = 1;
 	level = 2
 	},
-/obj/item/synthesized_instrument/trumpet,
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "gx" = (
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "gz" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2538,13 +2505,12 @@
 /turf/open,
 /area/ship/trade/cargo)
 "gI" = (
-/obj/random/maintenance,
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	dir = 4
+/obj/structure/hygiene/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "gL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2553,13 +2519,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "gM" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 21
 	},
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "gO" = (
@@ -2570,11 +2537,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "gP" = (
 /turf/wall/r_wall,
-/area/ship/trade/hidden)
+/area/ship/trade/crew/surgery)
 "gQ" = (
 /turf/wall,
 /area/ship/trade/hidden)
@@ -2684,46 +2651,37 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/wall{
-	can_open = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/ship/trade/hidden)
-"hl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/cash/c1000,
-/obj/random/coin,
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/turf/wall/r_wall,
+/area/ship/trade/hidden)
+"hl" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/wall,
 /area/ship/trade/hidden)
 "hm" = (
-/obj/item/stool/padded,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/firealarm{
-	pixel_y = 21
-	},
-/turf/floor/plating,
+/turf/wall,
 /area/ship/trade/hidden)
 "hr" = (
 /obj/structure/disposalpipe/segment{
@@ -2746,7 +2704,8 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "ht" = (
 /obj/effect/decal/cleanable/dirt/visible,
@@ -2784,7 +2743,7 @@
 	dir = 4
 	},
 /obj/structure/emergency_dispenser/north,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hv" = (
 /obj/structure/cable{
@@ -2830,7 +2789,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2848,7 +2807,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hy" = (
 /obj/item/crowbar,
@@ -2870,7 +2829,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2888,7 +2847,8 @@
 /obj/structure/disposalpipe/segment/bent{
 	dir = 8
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "hA" = (
 /obj/machinery/power/apc{
@@ -2925,6 +2885,15 @@
 "hD" = (
 /turf/wall/r_wall,
 /area/ship/trade/maintenance/atmos)
+"hE" = (
+/obj/structure/closet,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/random/clothing,
+/obj/item/backpack/dufflebag,
+/turf/floor/tiled/freezer,
+/area/ship/trade/crew/wash)
 "hF" = (
 /turf/wall,
 /area/ship/trade/maintenance/atmos)
@@ -3253,7 +3222,8 @@
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/engineering)
 "in" = (
-/turf/floor/plating,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "io" = (
 /obj/structure/cable{
@@ -3507,11 +3477,14 @@
 "iN" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "iO" = (
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "iQ" = (
 /turf/wall/r_wall,
@@ -4415,7 +4388,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "mf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4477,6 +4451,21 @@
 "nb" = (
 /turf/wall,
 /area/ship/trade/garden)
+"nc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "nd" = (
 /obj/machinery/light{
 	dir = 8;
@@ -4611,16 +4600,12 @@
 /turf/wall/r_wall/hull,
 /area/ship/trade/crew/medbay)
 "oo" = (
-/obj/machinery/light,
-/obj/machinery/optable,
-/obj/item/chems/drinks/glass2/coffeecup/britcup,
-/obj/item/chems/glass/rag,
-/obj/machinery/body_scan_display{
-	pixel_y = -21;
-	dir = 1
+/obj/structure/skele_stand{
+	name = "Lost Skeleton Spookers";
+	desc = "Once upon a time he looked over the books. Now all he looks over is ruin."
 	},
-/turf/floor/tiled/white,
-/area/ship/trade/crew/medbay)
+/turf/floor/plating,
+/area/ship/trade/hidden)
 "op" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4722,7 +4707,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "pM" = (
 /obj/machinery/smartfridge/chemistry,
@@ -4772,8 +4757,9 @@
 /turf/floor/tiled,
 /area/ship/trade/garden)
 "qd" = (
-/turf/wall/r_wall,
-/area/space)
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "qg" = (
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
@@ -4783,6 +4769,7 @@
 /obj/machinery/vending/cola{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "qt" = (
@@ -4840,6 +4827,16 @@
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
 /area/ship/trade/shuttle/rescue)
+"qN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/monotile,
+/area/ship/trade/command/hallway)
 "qO" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4857,6 +4854,8 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "qT" = (
@@ -4948,9 +4947,18 @@
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "rR" = (
-/obj/item/flashlight,
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/maintenance/hallway)
+"sa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "sb" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
@@ -5126,9 +5134,46 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/floor/tiled,
 /area/ship/trade/garden)
+"tf" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/turf/floor/tiled/freezer,
+/area/ship/trade/crew/wash)
 "tg" = (
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
+"th" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Laundry";
+	normalspeed = 0;
+	stripe_color = "#b7f27d"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/crew/wash)
 "to" = (
 /obj/structure/closet/crate,
 /obj/item/radio,
@@ -5245,7 +5290,8 @@
 /obj/effect/paint/brown,
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
-/turf/floor/tiled/techmaint,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/dock)
 "uD" = (
 /obj/machinery/port_gen/pacman/super,
@@ -5436,14 +5482,12 @@
 /turf/wall/r_wall/hull,
 /area/ship/trade/command/captain)
 "wU" = (
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/floor/tiled/freezer,
-/area/ship/trade/crew/wash)
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "xc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5456,6 +5500,13 @@
 	},
 /turf/space,
 /area/space)
+"xl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/monotile,
+/area/ship/trade/dock)
 "xn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5493,7 +5544,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "xI" = (
 /obj/machinery/light,
@@ -5530,7 +5582,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "xS" = (
 /turf/floor/carpet,
@@ -5614,6 +5671,12 @@
 	},
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
+"yO" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/monotile,
+/area/ship/trade/dock)
 "yZ" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -5660,6 +5723,10 @@
 	},
 /turf/floor/tiled/techfloor,
 /area/ship/trade/maintenance/atmos)
+"zR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "zY" = (
 /obj/structure/lattice,
 /obj/structure/handrail{
@@ -5694,6 +5761,30 @@
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
 /area/ship/trade/crew/medbay/chemistry)
+"At" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "conpipe-c"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Washroom APC";
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 21
+	},
+/turf/floor/tiled/freezer,
+/area/ship/trade/crew/wash)
 "AB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -5714,6 +5805,16 @@
 /obj/effect/paint/brown,
 /turf/wall,
 /area/ship/trade/crew/wash)
+"AI" = (
+/obj/machinery/power/apc{
+	name = "Medical Bay APC";
+	pixel_y = -22
+	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/firstaid/surgery,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "AO" = (
 /obj/item/stool/padded,
 /obj/abstract/landmark/start{
@@ -5745,8 +5846,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
+"AY" = (
+/obj/item/synthesized_instrument/trumpet,
+/turf/floor/plating,
+/area/ship/trade/hidden)
 "Ba" = (
 /obj/machinery/hologram/holopad/longrange,
 /turf/floor/tiled,
@@ -5819,18 +5924,7 @@
 /turf/floor/plating,
 /area/ship/trade/shuttle/outgoing/general)
 "BP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "BW" = (
@@ -5886,12 +5980,24 @@
 	id_tag = "tradeship_dock_port";
 	pixel_x = -20
 	},
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "Cg" = (
 /obj/abstract/ramp_sculptor/east,
 /turf/wall/natural,
 /area/space)
+"Ch" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/structure/undies_wardrobe,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/floor/tiled/freezer,
+/area/ship/trade/crew/wash)
 "Co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5953,12 +6059,15 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/maintenance/atmos)
 "Dc" = (
-/obj/structure/emergency_dispenser/north,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "bulb1"
 	},
 /obj/item/stool/padded,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 22
+	},
 /turf/floor/tiled/dark,
 /area/ship/trade/hangout)
 "Dd" = (
@@ -5973,6 +6082,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/saloon)
 "Dj" = (
@@ -5983,14 +6093,12 @@
 /turf/floor/tiled,
 /area/ship/trade/shuttle/rescue)
 "Dl" = (
-/obj/machinery/power/apc{
-	name = "Medical Bay APC";
-	pixel_y = -22
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/cable,
-/obj/machinery/icecream_vat,
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/obj/structure/iv_drip,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "Dq" = (
 /obj/effect/paint/brown,
 /turf/wall,
@@ -6022,6 +6130,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/hatch/autoname/command,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/shieldbay)
 "DC" = (
@@ -6066,7 +6175,10 @@
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "DV" = (
-/obj/machinery/vitals_monitor,
+/obj/machinery/light,
+/obj/machinery/computer/modular/preset/medical{
+	dir = 1
+	},
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "DY" = (
@@ -6186,6 +6298,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "EQ" = (
@@ -6222,9 +6335,11 @@
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "Fm" = (
-/obj/effect/paint/brown,
-/turf/wall,
-/area/ship/trade/hidden)
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/cargo)
 "Fv" = (
 /obj/machinery/door/window/southright,
 /obj/structure/table/marble,
@@ -6254,19 +6369,15 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "FW" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/obj/random_multi/single_item/captains_spare_id,
-/obj/item/cash/c1000,
-/obj/machinery/light_switch{
-	pixel_y = 25
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/random/single/textbook,
-/turf/floor/plating,
-/area/ship/trade/hidden)
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "FZ" = (
 /obj/machinery/power/smes/buildable/max_cap_in_out,
 /obj/structure/cable{
@@ -6389,6 +6500,13 @@
 	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
+"GV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "GY" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/power/apc{
@@ -6435,7 +6553,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "Hp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6447,7 +6565,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Hr" = (
 /obj/structure/cable{
@@ -6462,9 +6580,37 @@
 /turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "Hs" = (
-/obj/machinery/light,
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
+"HA" = (
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/monotile,
+/area/ship/trade/dock)
+"HB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
+"HO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/port)
 "HR" = (
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
@@ -6555,33 +6701,22 @@
 	dir = 8;
 	pixel_x = -21
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Iy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/floor/plating,
-/area/ship/trade/crew/hallway/port)
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "IA" = (
 /obj/effect/paint/red,
 /turf/wall/r_wall/hull,
 /area/ship/trade/maintenance/engine/aft)
 "IC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/hallway/starboard)
 "IH" = (
 /obj/structure/cable{
@@ -6592,7 +6727,7 @@
 "IJ" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/effect/floor_decal/corner/red/diagonal,
-/turf/floor/tiled,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/crew/kitchen)
 "IM" = (
 /turf/floor/plating/airless,
@@ -6640,6 +6775,12 @@
 	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
+"Ji" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/floor/plating,
+/area/ship/trade/hidden)
 "Jk" = (
 /obj/structure/bed/chair/office/dark,
 /obj/abstract/landmark/start{
@@ -6759,13 +6900,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Kd" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/floor/tiled/freezer,
+/area/ship/trade/crew/wash)
 "Kj" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -6861,6 +7008,7 @@
 	pixel_x = 32;
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "Lb" = (
@@ -6882,7 +7030,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "Ld" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6945,24 +7093,21 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/engine/aft)
 "Mc" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "bulb1"
-	},
+/obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/floor/tiled/freezer,
-/area/ship/trade/crew/wash)
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "Mo" = (
 /obj/structure/lattice,
 /obj/effect/paint/brown,
@@ -6985,9 +7130,14 @@
 /turf/floor/tiled,
 /area/ship/trade/crew/saloon)
 "MD" = (
-/obj/effect/paint/brown,
-/turf/wall,
-/area/ship/trade/unused)
+/obj/random/maintenance,
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	dir = 4
+	},
+/obj/machinery/vitals_monitor,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "MG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -7010,7 +7160,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Nb" = (
 /obj/structure/handrail{
@@ -7023,13 +7173,8 @@
 	dir = 4;
 	icon_state = "conpipe-c"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Washroom APC";
-	pixel_y = 22
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7037,14 +7182,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 21
-	},
-/turf/floor/tiled/freezer,
-/area/ship/trade/crew/wash)
+/turf/floor/tiled/dark,
+/area/ship/trade/hangout)
 "Nd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
 /turf/floor/plating,
@@ -7101,9 +7246,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/structure/bookcase/skill_books/random,
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "NM" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
@@ -7160,8 +7304,8 @@
 /obj/machinery/network/relay{
 	initial_network_id = "tradenet"
 	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "Og" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7174,6 +7318,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "Os" = (
@@ -7229,7 +7374,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/floor/plating,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
 "Pp" = (
 /obj/machinery/door/firedoor,
@@ -7268,6 +7413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/door/airlock/hatch/autoname/engineering,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/floor/tiled/steel_ridged,
 /area/ship/trade/maintenance/engineering)
 "PF" = (
@@ -7311,6 +7457,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "Ql" = (
@@ -7362,7 +7510,8 @@
 	dir = 1
 	},
 /obj/item/stack/tape_roll/duct_tape,
-/obj/item/firstaid/surgery,
+/obj/item/chems/drinks/glass2/coffeecup/britcup,
+/obj/item/chems/glass/rag,
 /turf/floor/tiled/white,
 /area/ship/trade/crew/medbay)
 "QS" = (
@@ -7404,19 +7553,16 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/mob/living/simple_animal/passive/fox{
+	name = "Frankie";
+	desc = "He's here to sniff out some scabs."
+	},
 /turf/floor/carpet/blue,
 /area/ship/trade/command/captain)
 "Rc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/stool/padded,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -21
-	},
-/turf/floor/wood/yew,
-/area/ship/trade/unused)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "Rl" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -7463,6 +7609,17 @@
 /obj/machinery/door/firedoor,
 /turf/floor/plating,
 /area/ship/trade/shuttle/rescue)
+"RT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -21
+	},
+/obj/structure/table,
+/turf/floor/tiled/white,
+/area/ship/trade/crew/surgery)
 "RW" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
@@ -7473,7 +7630,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "Sc" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -7525,8 +7684,22 @@
 /obj/effect/paint/brown,
 /turf/wall/r_wall,
 /area/ship/trade/command/fmate)
+"Sq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/floor/tiled/techmaint,
+/area/ship/trade/crew/hallway/starboard)
 "Sr" = (
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/maintenance/hallway)
 "Sy" = (
 /obj/machinery/power/terminal{
@@ -7573,7 +7746,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/floor/plating,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "SQ" = (
 /obj/structure/cable{
@@ -7680,6 +7854,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/hallway)
 "UD" = (
@@ -7994,6 +8169,12 @@
 /obj/effect/shuttle_landmark/docking_arm_port/shuttle,
 /turf/floor/tiled,
 /area/ship/trade/shuttle/outgoing/general)
+"Yj" = (
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/dock)
 "Yl" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 4;
@@ -8064,7 +8245,9 @@
 /turf/floor/plating,
 /area/ship/trade/shuttle/outgoing/engineering)
 "YN" = (
-/turf/floor/plating,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/filth,
+/turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
 "YR" = (
 /obj/effect/paint/red,
@@ -10420,15 +10603,15 @@ YS
 vj
 Si
 vj
+AH
+fT
+aC
+AH
 Cd
 dY
 ey
-ey
-Vc
-AH
-fT
 gn
-AH
+Vc
 mX
 mX
 rb
@@ -10502,15 +10685,15 @@ Ui
 cT
 dt
 cU
+fE
+Ch
+hE
+yA
 Dq
 Bc
-nH
-eP
-fk
-fE
 fU
 go
-yA
+fk
 nb
 Sc
 sb
@@ -10584,15 +10767,15 @@ cU
 dh
 du
 zc
-lZ
-nW
-ez
-nH
-Jp
 fE
-wU
+Kh
 vS
 gA
+lZ
+nW
+wU
+nH
+Jp
 nb
 sY
 WO
@@ -10666,15 +10849,15 @@ az
 di
 dv
 dM
-lZ
-Cc
-eA
-eQ
-bl
 fE
-Mc
+tf
 gp
 gB
+lZ
+Cc
+Mc
+GV
+bl
 nb
 pb
 Co
@@ -10748,15 +10931,15 @@ cU
 nd
 dw
 dN
-lZ
-Dc
-eB
-eR
-fm
 fE
-Nc
+At
 gq
 gC
+lZ
+Dc
+Nc
+eQ
+fm
 mb
 qb
 vb
@@ -10830,15 +11013,15 @@ cU
 cT
 dx
 cT
-lZ
+fE
+th
+fE
+fE
 lZ
 lZ
 eS
 lZ
-fE
-fX
-fE
-fE
+lZ
 mb
 mb
 wb
@@ -10905,15 +11088,15 @@ cf
 Mw
 oi
 qp
+BP
+BP
 cE
-cE
-cE
-in
-aC
+zR
+aE
 Hp
 MX
 Kl
-cE
+nc
 qR
 BP
 aE
@@ -10921,11 +11104,11 @@ pt
 pG
 MX
 Iw
-cE
+in
 aI
 Hr
 FT
-HT
+Xz
 HT
 hF
 hP
@@ -10983,31 +11166,31 @@ Mw
 tg
 Ce
 EM
-tg
+UV
 uu
+BP
+gv
 cE
-cE
-cE
-cE
-in
-cE
+BP
+gv
+BP
 Kd
 Hp
-in
-in
-in
-in
-Iy
+BP
+BP
+HO
+zR
+BP
 IO
 in
 AQ
 in
-in
-in
+cE
+cE
 ra
-Fl
+xB
 Sr
-Sr
+Xz
 HT
 hF
 hQ
@@ -11066,14 +11249,14 @@ tg
 bN
 bQ
 cl
-cu
+Yj
 cE
 cE
 Nx
 cE
 cE
 cW
-aC
+aE
 dy
 dO
 ea
@@ -11089,7 +11272,7 @@ gL
 aJ
 hi
 hr
-Xz
+rR
 HT
 wG
 bj
@@ -11144,7 +11327,7 @@ CP
 oK
 oK
 aO
-tg
+UV
 bC
 be
 uc
@@ -11161,7 +11344,7 @@ dP
 eb
 eb
 eb
-eU
+Fm
 eb
 eb
 eb
@@ -11226,7 +11409,7 @@ EQ
 qT
 Mw
 br
-tg
+yO
 aR
 dZ
 dZ
@@ -11308,7 +11491,7 @@ EQ
 aj
 ap
 tg
-tg
+UV
 bD
 dZ
 GJ
@@ -11335,8 +11518,8 @@ fZ
 VP
 eb
 hu
-HT
-HT
+Xz
+fX
 hG
 pT
 ij
@@ -11468,11 +11651,11 @@ UB
 EQ
 SQ
 Bb
-Jh
+qN
 am
 ap
 UV
-tg
+UV
 DE
 dZ
 PF
@@ -11499,8 +11682,8 @@ fZ
 gW
 eb
 hw
+fX
 Xz
-HT
 hG
 hV
 il
@@ -11582,7 +11765,7 @@ eV
 eb
 hx
 Xz
-HT
+Xz
 hG
 hW
 il
@@ -11636,7 +11819,7 @@ ae
 as
 SC
 tg
-tg
+HA
 bG
 bk
 vc
@@ -11663,7 +11846,7 @@ eU
 eb
 eb
 hy
-HT
+eR
 iN
 hG
 hX
@@ -11727,7 +11910,7 @@ cG
 cG
 LC
 cL
-YN
+cG
 dc
 aD
 dF
@@ -11745,8 +11928,8 @@ gO
 aK
 hj
 hz
-Sr
-Sr
+Xz
+Xz
 hJ
 hJ
 KO
@@ -11800,35 +11983,35 @@ Rq
 ER
 Pp
 Mw
-tg
+UV
 lj
 at
-ah
+xl
 Lm
 IH
+FW
+sa
 Sb
-Sb
-Sb
-IH
-IH
+HB
+FW
 db
 aS
-cG
-cG
 YN
-YN
+cG
+qd
+eP
 SL
 fR
 YN
-YN
-Ey
-YN
 cG
+Ey
+qd
+YN
 ra
 xB
-Xz
-Sr
-Sr
+rR
+HT
+HT
 hJ
 Zc
 io
@@ -11891,11 +12074,11 @@ VX
 yF
 cG
 cG
-YN
-YN
-aD
-SL
-hs
+eB
+Iy
+IC
+Sq
+rP
 TR
 rP
 KZ
@@ -11904,12 +12087,12 @@ aD
 gM
 hs
 xO
-IC
-YN
+cG
+cG
 aN
 Fl
 HY
-HT
+eR
 aB
 hJ
 Jb
@@ -12068,9 +12251,9 @@ fu
 QH
 ee
 gd
-gv
 Rc
-gQ
+Rc
+RT
 hl
 Gj
 xc
@@ -12147,17 +12330,17 @@ Kw
 eL
 fd
 Kw
-oo
+nR
 ev
 ge
 gw
 Dl
-gQ
+AI
 hm
-sS
-sS
+Ji
+oo
 hB
-qd
+sI
 Bx
 Bx
 PH
@@ -12229,17 +12412,17 @@ Kw
 Kw
 Et
 Kw
-DV
-ee
+Kw
+eA
 NI
-rR
 Hs
+Hs
+ez
 gQ
 sS
-sS
-sS
+AY
 qg
-gP
+sI
 oQ
 oQ
 oQ
@@ -12316,12 +12499,12 @@ ee
 Oc
 gx
 gI
+MD
 gQ
-FW
 sS
 sS
 hC
-gP
+sI
 aa
 aa
 aa
@@ -12393,17 +12576,17 @@ pq
 Kw
 LA
 Kw
-nR
+DV
 ee
 aM
 gg
-MD
+gg
+gg
 sI
 sI
 sI
 sI
-Fm
-aa
+sI
 aa
 aa
 aa

--- a/maps/tradeship_alt/tradeship-3.dmm
+++ b/maps/tradeship_alt/tradeship-3.dmm
@@ -11,7 +11,9 @@
 	name = "External Blast Doors"
 	},
 /turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "ac" = (
 /obj/structure/lattice,
 /turf/space,
@@ -48,14 +50,15 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/solars)
 "ai" = (
-/obj/effect/paint/brown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/bed/padded,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/wall/r_wall/hull,
-/area/ship/trade/bridge_unused)
+/obj/item/bedsheet/mime,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "aj" = (
 /obj/item/newspaper,
 /turf/floor/reinforced/airless,
@@ -263,11 +266,8 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/solars)
 "aH" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/wall/r_wall,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/drunk_tank)
 "aI" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -564,14 +564,25 @@
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "cO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/wall/r_wall,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
+"cV" = (
+/turf/space,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "dm" = (
 /obj/abstract/level_data_spawner/main_level{
 	name = "Tradeship Upper Deck"
@@ -579,15 +590,33 @@
 /turf/space,
 /area/space)
 "dq" = (
-/obj/item/clothing/head/bearpelt,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "ds" = (
 /obj/machinery/network/router{
 	initial_network_id = "tradenet"
 	},
 /turf/floor/bluegrid,
 /area/ship/trade/comms)
+"dw" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/mime,
+/obj/machinery/light_switch{
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32;
+	dir = 4
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "ex" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -600,12 +629,18 @@
 	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
+"eZ" = (
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "fi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
 "gb" = (
@@ -622,7 +657,6 @@
 /turf/floor/plating,
 /area/ship/trade/maintenance/solars)
 "gw" = (
-/obj/item/caution/cone,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -632,8 +666,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "gY" = (
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
@@ -663,6 +703,17 @@
 	},
 /turf/floor/plating/airless,
 /area/space)
+"iw" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -21
+	},
+/obj/effect/decal/cleanable/vomit,
+/obj/structure/hygiene/toilet{
+	dir = 1
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "iz" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-10"
@@ -678,21 +729,18 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
 "jv" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "scraplock";
-	name = "External Blast Doors"
+/obj/structure/bed/chair/comfy,
+/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/door_timer/cell_1{
+	id_tag = "tank";
+	name = "Drunk Tank";
+	pixel_x = 32
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/drunk_tank)
 "jy" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -716,6 +764,45 @@
 "jJ" = (
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
+"jM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Security APC";
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/drunk_tank)
+"lQ" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/command/bridge)
+"lV" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "ml" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
 /turf/floor/bluegrid,
@@ -744,6 +831,12 @@
 /obj/item/radio,
 /obj/random/drinkbottle,
 /obj/abstract/landmark/paperwork_spawn_tradeship,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "mV" = (
@@ -760,7 +853,9 @@
 /area/space)
 "ne" = (
 /turf/wall/r_wall,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "ng" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -797,8 +892,11 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "ow" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -814,8 +912,11 @@
 	dir = 1;
 	level = 2
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "pt" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
@@ -830,6 +931,13 @@
 /obj/structure/lattice,
 /turf/open,
 /area/ship/trade/command/bridge_upper)
+"pv" = (
+/obj/structure/table,
+/obj/random/plushie,
+/obj/item/synthesized_instrument/violin,
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "pC" = (
 /obj/item/wrench,
 /obj/structure/handrail{
@@ -837,26 +945,48 @@
 	},
 /turf/floor/reinforced/airless,
 /area/space)
+"qw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
+"qY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -21
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "rl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
+"ru" = (
+/obj/machinery/computer/modular/preset/security{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "rw" = (
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+/turf/unsimulated/dark_filler,
+/area/space)
 "rR" = (
 /obj/machinery/shipsensors,
 /obj/structure/cable{
@@ -912,6 +1042,10 @@
 /obj/item/documents/tradehouse/account,
 /obj/item/documents/tradehouse/personnel,
 /obj/abstract/landmark/paperwork_spawn_tradeship,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "tG" = (
@@ -922,6 +1056,13 @@
 /obj/effect/paint/brown,
 /turf/wall/r_wall/hull,
 /area/ship/trade/command/bridge_upper)
+"um" = (
+/obj/machinery/vending/security,
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "uM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -929,14 +1070,24 @@
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "uT" = (
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "vi" = (
 /obj/structure/handrail{
 	dir = 8
 	},
 /turf/floor/reinforced/airless,
 /area/space)
+"vH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/hygiene/sink{
+	pixel_y = 21
+	},
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "vR" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/machinery/firealarm{
@@ -972,9 +1123,14 @@
 /turf/floor/plating/airless,
 /area/space)
 "wq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "wN" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -1004,19 +1160,35 @@
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "xr" = (
-/obj/random/shoes,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/machinery/suit_cycler/security/prepared,
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "xu" = (
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /turf/open,
 /area/ship/trade/command/bridge)
+"xK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
+"yn" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "yp" = (
 /obj/item/stack/material/ore/iron,
 /turf/floor/reinforced/airless,
@@ -1033,10 +1205,12 @@
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/comms)
 "yM" = (
-/obj/item/stack/material/rods,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "ze" = (
 /obj/structure/bed/chair/comfy/teal{
 	dir = 1
@@ -1048,16 +1222,22 @@
 	icon_state = "1-2"
 	},
 /obj/effect/overmap/visitable/ship/tradeship,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "zn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/door/airlock/hatch/autoname/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/wall/r_wall,
+/turf/floor/tiled/steel_ridged,
 /area/ship/trade/command/bridge_upper)
 "zr" = (
 /obj/machinery/computer/account_database,
@@ -1073,9 +1253,19 @@
 /turf/floor/plating/airless,
 /area/space)
 "zY" = (
-/obj/effect/paint/brown,
-/turf/wall/r_wall/hull,
-/area/ship/trade/bridge_unused)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/eastleft{
+	id_tag = "tank";
+	name = "drunk tank"
+	},
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/drunk_tank)
 "Al" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -1112,6 +1302,10 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/comms)
+"Aw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "AK" = (
 /obj/machinery/network/mainframe{
 	initial_network_id = "tradenet"
@@ -1120,17 +1314,10 @@
 /area/ship/trade/comms)
 "AX" = (
 /obj/effect/paint/brown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/wall/r_wall/hull,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "Bu" = (
 /obj/machinery/network/requests_console{
 	announcementConsole = 1;
@@ -1150,23 +1337,15 @@
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
 "Db" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id_tag = "scraplock";
-	name = "External Blast Doors"
-	},
-/turf/floor/plating/airless,
-/area/ship/trade/bridge_unused)
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/floor/plating,
+/area/ship/trade/drunk_tank)
 "Dg" = (
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
@@ -1176,7 +1355,19 @@
 /area/space)
 "Dr" = (
 /turf/floor/reinforced/airless,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
+"DB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/drunk_tank)
 "DP" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-5"
@@ -1195,9 +1386,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/tape_barricade/engineering,
-/turf/floor/tiled/techfloor/grid,
-/area/ship/trade/bridge_unused)
+/turf/floor/tiled/steel_ridged,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "Ev" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1276,6 +1468,9 @@
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/command/bridge_upper)
 "Io" = (
@@ -1305,17 +1500,9 @@
 /turf/wall/r_wall,
 /area/ship/trade/command/bridge)
 "JQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/floor/tiled/dark,
-/area/ship/trade/command/bridge)
+/obj/effect/paint/brown,
+/turf/wall/r_wall,
+/area/ship/trade/drunk_tank)
 "Ks" = (
 /obj/item/mollusc/barnacle{
 	pixel_x = -14
@@ -1324,16 +1511,25 @@
 /area/space)
 "KG" = (
 /obj/random/trash,
-/obj/item/bone/skull/deer,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light/small{
+	icon_state = "bulb1"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "KK" = (
 /turf/open,
 /area/ship/trade/command/bridge)
 "KS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "Lf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner"
@@ -1379,6 +1575,17 @@
 /obj/item/solar_assembly,
 /turf/floor/plating/airless,
 /area/space)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/drunk_tank)
 "MA" = (
 /obj/item/stack/cable_coil/yellow,
 /turf/floor/reinforced/airless,
@@ -1462,6 +1669,16 @@
 	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
+"Qt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/visible,
+/turf/floor/tiled/dark,
+/area/ship/trade/drunk_tank)
 "QB" = (
 /obj/abstract/landmark/paperwork_finish_tradeship,
 /obj/structure/cable{
@@ -1526,18 +1743,20 @@
 /turf/floor/plating,
 /area/ship/trade/command/bridge_upper)
 "Tt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/mob/living/simple_animal/passive/fox{
-	name = "Frankie";
-	desc = "He's here to sniff out some scabs."
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "Tx" = (
 /obj/machinery/computer/modular/preset/engineering,
 /obj/effect/floor_decal/corner/yellow{
@@ -1554,6 +1773,21 @@
 	},
 /turf/floor/tiled/dark,
 /area/ship/trade/command/bridge)
+"Ty" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/floor/tiled/monotile,
+/area/ship/trade/command/bridge_upper)
 "Ua" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -1568,6 +1802,16 @@
 /obj/machinery/commsrelay,
 /turf/floor/bluegrid,
 /area/ship/trade/comms)
+"Uw" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "scraplock";
+	name = "External Blast Doors"
+	},
+/obj/machinery/door/firedoor,
+/turf/floor/plating,
+/area/ship/trade/drunk_tank)
 "UX" = (
 /obj/effect/shuttle_landmark/automatic,
 /turf/space,
@@ -1590,7 +1834,9 @@
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "Wp" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -1632,8 +1878,17 @@
 /area/space)
 "XF" = (
 /obj/random/trash,
-/turf/floor/plating,
-/area/ship/trade/bridge_unused)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red/mono,
+/turf/floor/tiled/dark/monotile,
+/area/ship/trade/bridge_unused{
+	name = "\improper Security"
+	})
 "XQ" = (
 /obj/machinery/door/airlock/double/engineering,
 /obj/machinery/door/firedoor,
@@ -1664,17 +1919,8 @@
 /area/ship/trade/command/bridge)
 "YX" = (
 /obj/effect/paint/brown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/wall/r_wall,
-/area/ship/trade/command/bridge)
+/turf/wall/r_wall/hull,
+/area/ship/trade/drunk_tank)
 "Zx" = (
 /obj/structure/handrail{
 	dir = 4
@@ -1695,6 +1941,10 @@
 	},
 /turf/floor/tiled/techfloor/grid,
 /area/ship/trade/comms)
+"ZL" = (
+/obj/effect/paint/brown,
+/turf/wall,
+/area/ship/trade/drunk_tank)
 "ZT" = (
 /obj/machinery/light{
 	dir = 4
@@ -4767,7 +5017,7 @@ xu
 Xb
 PZ
 NQ
-ex
+cO
 PZ
 bE
 SQ
@@ -4926,8 +5176,8 @@ mn
 On
 hJ
 Dg
-KK
-KK
+lQ
+lQ
 zn
 HR
 rl
@@ -5007,10 +5257,10 @@ jJ
 ow
 jJ
 uM
-rw
+tG
 KK
 KK
-cO
+Xb
 PZ
 wc
 nZ
@@ -5089,13 +5339,13 @@ Wp
 jJ
 jJ
 uM
-JQ
+jJ
 IK
 IK
-cO
+Xb
 ja
 vR
-ex
+Ty
 PZ
 ZT
 SQ
@@ -5171,16 +5421,16 @@ Ql
 cB
 Yr
 xj
-YX
-ai
-ai
+ad
 AX
-aH
+AX
+AX
+ne
 ne
 DY
 ne
 ne
-Xb
+ne
 ax
 ax
 ax
@@ -5254,15 +5504,15 @@ JH
 JH
 ad
 ad
-zY
-zY
-zY
-uT
+AX
+AX
+AX
+um
 oq
 gw
 uT
 xr
-tJ
+AX
 ay
 ay
 ae
@@ -5336,7 +5586,7 @@ aa
 aa
 aa
 aa
-aa
+cV
 Dr
 ab
 yM
@@ -5418,15 +5668,15 @@ aa
 aa
 aa
 aa
-zY
-zY
-zY
+AX
+AX
+AX
 dq
-uT
+xK
 XF
 uT
 KG
-zY
+AX
 aq
 ae
 Lx
@@ -5501,14 +5751,14 @@ aa
 aa
 aa
 aa
-zY
-zY
-ne
-ne
+YX
+YX
+jM
+Mz
+DB
 jv
-jv
-zY
-zY
+ru
+AX
 ax
 ax
 ax
@@ -5583,14 +5833,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-zY
+aH
+Db
 zY
 Db
 Db
-zY
-ax
+JQ
+AX
+AX
 aa
 ax
 ax
@@ -5665,14 +5915,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+YX
+lV
+qw
+eZ
+iw
+JQ
+rw
+rw
 aa
 aa
 aa
@@ -5747,14 +5997,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+YX
+vH
+Qt
+Aw
+qY
+JQ
+rw
+rw
 aa
 aa
 aa
@@ -5829,14 +6079,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+YX
+ai
+pv
+yn
+dw
+JQ
+rw
+rw
 aa
 aa
 aa
@@ -5911,12 +6161,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+YX
+ZL
+Uw
+Uw
+JQ
+JQ
 aa
 aa
 aa

--- a/maps/tradeship_alt/tradeship_areas.dm
+++ b/maps/tradeship_alt/tradeship_areas.dm
@@ -61,6 +61,18 @@
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	holomap_color = HOLOMAP_AREACOLOR_MEDICAL
 
+/area/ship/trade/crew/surgery
+	name = "\improper Operating Room"
+	icon_state = "medbay"
+	area_flags = AREA_FLAG_RAD_SHIELDED
+	holomap_color = HOLOMAP_AREACOLOR_MEDICAL
+
+/area/ship/trade/crew/morgue
+	name = "\improper Morgue"
+	icon_state = "purple"
+	area_flags = AREA_FLAG_RAD_SHIELDED
+	holomap_color = HOLOMAP_AREACOLOR_MEDICAL
+
 /area/ship/trade/cargo
 	name = "\improper Cargo Hold"
 	icon_state = "quartstorage"


### PR DESCRIPTION

## Description of changes
Overhauls to every z-level of Ivenmoth Fishfinder.
Tradeship-0: Enclave expanded, library added to yinglet leadership room, janitorials added, farming area expanded and redone.
Tradeship-1: Cargo Hold expanded, science goggles added to Research, Drunk Tank removed and replaced with a Morgue.
Tradeship-2: Library replaced with a Surgery Room, rearranged the positions of the RecRoom and Laundry to make more sense. Added filth.
Tradeship-3: Security added, Drunk Tank added, walkway from the bridge to Telecomms and Security added.

## Why and what will this PR improve
Expands certain areas to accommodate more players, adds previously unacquirable items, and differentiates Fishfinder from Tradeship further.

## Authorship
<!-- Describe original authors of changes to credit them. -->
CEG

## Changelog
:cl:
add: added Morgue, Janitorials, Surgery Room, science goggles, and Security
del: removed Old Library, Bridge Storage Hold
tweak: Relocated Drunk Tank, Library, RecRoom, and Laundry Room
/:cl:
