### PR TITLE
Updates To Fishfinder Jobs

### DIFF
--- a/maps/tradeship_alt/jobs/civilian.dm
+++ b/maps/tradeship_alt/jobs/civilian.dm
@@ -28,7 +28,7 @@
 	outfit_type = /decl/outfit/job/tradeship/hand
 	min_skill = list( SKILL_PILOT    = SKILL_ADEPT )
 	max_skill = list( SKILL_PILOT    = SKILL_MAX )
-	skill_points = 18
+	skill_points = 22
 	alt_titles = list("Helmsying")
 	department_types = list(/decl/department/civilian)
 	economic_power = 1

--- a/maps/tradeship_alt/jobs/yinglets.dm
+++ b/maps/tradeship_alt/jobs/yinglets.dm
@@ -17,7 +17,11 @@
 	outfit_type = /decl/outfit/job/yinglet/scout
 	access = list(
 		access_eva,
-		access_research
+		access_research,
+		access_security,
+		access_sec_doors,
+		access_brig,
+		access_bridge
 	)
 	min_skill = list(
 		SKILL_EVA      = SKILL_ADEPT,
@@ -29,7 +33,7 @@
 		SKILL_SCIENCE  = SKILL_MAX,
 		SKILL_COMBAT   = SKILL_EXPERT,
 		SKILL_WEAPONS  = SKILL_EXPERT,
-		SKILL_LITERACY = SKILL_BASIC
+		SKILL_LITERACY = SKILL_ADEPT
 	)
 	skill_points = 28
 
@@ -44,10 +48,10 @@
 	alt_titles = list(
 		"Patriarch of Cooking" = /decl/outfit/job/yinglet/patriarch/cook,
 		"Patriarch of Scouting" = /decl/outfit/job/yinglet/patriarch/scout,
-		"Patriarch of Security",
+		"Patriarch of Security" = /decl/outfit/job/yinglet/patriarch/cop,
 		"Patriarch of Botany" )
 	min_skill = list(
-		SKILL_WEAPONS      = SKILL_BASIC,
+		SKILL_WEAPONS      = SKILL_EXPERT,
 		SKILL_FINANCE      = SKILL_EXPERT,
 		SKILL_PILOT        = SKILL_ADEPT,
 		SKILL_COMPUTER     = SKILL_BASIC,

--- a/maps/tradeship_alt/outfits/_outfits.dm
+++ b/maps/tradeship_alt/outfits/_outfits.dm
@@ -4,7 +4,7 @@
 	pda_type = /obj/item/modular_computer/pda
 	pda_slot = slot_l_store_str
 	suit = /obj/item/clothing/suit/jacket/redcoat
-	l_ear = null
+	l_ear = /obj/item/radio/headset/headset_service
 	r_ear = null
 	yinglet_suit_fallback = TRUE
 

--- a/maps/tradeship_alt/outfits/yinglets.dm
+++ b/maps/tradeship_alt/outfits/yinglets.dm
@@ -5,12 +5,14 @@
 	name = "Tradeship - Enclave Scout"
 	uniform = /obj/item/clothing/pants/loincloth/yinglet/scout
 	head = /obj/item/clothing/head/yinglet/scout
+	l_ear = /obj/item/radio/headset/headset_service
 
 /decl/outfit/job/yinglet/patriarch
 	name = "Tradeship - Enclave Patriarch"
 	suit = /obj/item/clothing/suit/robe/yinglet/fancy
 	id_type = /obj/item/card/id/silver
 	pda_type = /obj/item/modular_computer/pda/heads
+	l_ear = /obj/item/radio/headset/headset_service
 
 /decl/outfit/job/yinglet/matriarch
 	name = "Tradeship - Enclave Matriarch"
@@ -30,3 +32,17 @@
 	head = /obj/item/clothing/head/yinglet/scout
 	suit = /obj/item/clothing/suit/robe/yinglet/fancy
 	pda_type = /obj/item/modular_computer/pda/heads
+
+/decl/outfit/job/yinglet/patriarch/cop
+	name = "Tradeship - Patriarch of Security"
+	glasses = /obj/item/clothing/glasses/sunglasses/sechud
+	l_ear = /obj/item/radio/headset/heads/hos
+	gloves = /obj/item/clothing/gloves/thick
+	shoes = /obj/item/clothing/shoes/jackboots
+	backpack_contents = list(/obj/item/handcuffs = 1)
+	uniform = /obj/item/clothing/jumpsuit/security
+	l_pocket = /obj/item/flash
+	r_pocket = /obj/item/handcuffs
+	id_type = /obj/item/card/id/ministation/security
+	pda_type = /obj/item/modular_computer/pda/security
+	suit = /obj/item/clothing/suit/jacket/redcoat/officer

--- a/maps/tradeship_alt/tradeship-1.dmm
+++ b/maps/tradeship_alt/tradeship-1.dmm
@@ -97,6 +97,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/chems/pill/gleam,
 /turf/floor/plating,
 /area/ship/trade/cargo/lower)
 "al" = (
@@ -2354,6 +2355,9 @@
 	},
 /turf/floor/reinforced,
 /area/space)
+"qr" = (
+/turf/floor/tiled/white,
+/area/ship/trade/science/fabricaton)
 "qF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2426,6 +2430,7 @@
 /area/ship/trade/science/fabricaton)
 "sM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/fabricator/industrial,
 /turf/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "sY" = (
@@ -3008,6 +3013,7 @@
 	dir = 1;
 	level = 2
 	},
+/obj/machinery/fabricator/filled,
 /turf/floor/tiled/white,
 /area/ship/trade/science/fabricaton)
 "Js" = (
@@ -3059,6 +3065,12 @@
 	},
 /turf/floor/lino,
 /area/ship/trade/crew/dorms2)
+"Lw" = (
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/effect/decal/cleanable/dirt/visible,
+/obj/structure/mech_wreckage,
+/turf/floor/tiled,
+/area/ship/trade/cargo/lower)
 "Lx" = (
 /obj/structure/closet/crate,
 /obj/item/strangerock,
@@ -5700,12 +5712,12 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+ca
+ca
+ca
+cr
+cr
+cP
 aa
 aa
 aa
@@ -5783,10 +5795,10 @@ Va
 ag
 Va
 ca
-ca
-ca
-cr
-cr
+HY
+Rs
+Nc
+Ic
 cP
 cZ
 cZ
@@ -5865,11 +5877,11 @@ iQ
 lD
 yT
 sB
-HY
-Rs
-Nc
-Ic
-cP
+qr
+qr
+qr
+qr
+sB
 da
 NL
 NL
@@ -6923,7 +6935,7 @@ he
 he
 lw
 du
-Sc
+Lw
 aU
 Lx
 Zd

--- a/maps/tradeship_alt/tradeship-2.dmm
+++ b/maps/tradeship_alt/tradeship-2.dmm
@@ -610,10 +610,6 @@
 /area/ship/trade/cargo)
 "bo" = (
 /obj/random/maintenance,
-/obj/structure/sign/warning/vacuum{
-	dir = 8;
-	pixel_x = 34
-	},
 /turf/floor/tiled/monotile,
 /area/ship/trade/dock)
 "bq" = (
@@ -768,13 +764,8 @@
 /turf/floor/plating,
 /area/ship/trade/dock)
 "bB" = (
-/obj/effect/decal/cleanable/dirt/visible,
-/obj/structure/sign/warning/vacuum{
-	dir = 4;
-	pixel_x = -34
-	},
-/turf/floor/tiled/monotile,
-/area/ship/trade/dock)
+/turf/floor/plating/airless,
+/area/space)
 "bC" = (
 /obj/effect/decal/cleanable/dirt/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1088,6 +1079,11 @@
 /obj/structure/table/woodentable,
 /obj/item/box/glasses/rocks,
 /obj/item/synthesized_instrument/guitar,
+/obj/item/chems/drinks/shaker,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	pixel_y = -10;
+	dir = 4
+	},
 /turf/floor/tiled,
 /area/ship/trade/crew/saloon)
 "cP" = (
@@ -2141,6 +2137,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/item/pill_bottle/gleam,
 /turf/floor/plating/airless,
 /area/ship/trade/maintenance/engine/starboard)
 "fB" = (
@@ -2339,11 +2336,10 @@
 /turf/floor/plating/airless,
 /area/ship/trade/maintenance/engine/port)
 "gm" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/space,
+/turf/floor/plating/airless,
 /area/space)
 "gn" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -4585,6 +4581,22 @@
 	dir = 4;
 	pixel_x = -21
 	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/chems/drinks/milk,
+/obj/item/chems/drinks/milk,
+/obj/item/chems/drinks/milk,
+/obj/item/chems/drinks/milk,
+/obj/item/chems/drinks/soymilk,
+/obj/item/chems/drinks/soymilk,
+/obj/item/chems/drinks/soymilk,
+/obj/item/chems/drinks/soymilk,
+/obj/item/box/fancy/egg_box,
+/obj/item/box/fancy/egg_box,
+/obj/item/box/fancy/egg_box,
+/obj/item/box/fancy/egg_box,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "om" = (
@@ -5276,6 +5288,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/item/chems/pill/gleam,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "uu" = (
@@ -5963,6 +5976,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/item/chems/pill/gleam,
 /turf/floor/tiled/dark,
 /area/ship/trade/hangout)
 "Cd" = (
@@ -6862,7 +6876,10 @@
 	dir = 9
 	},
 /obj/structure/table/woodentable,
-/obj/item/chems/drinks/shaker,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 4;
+	pixel_y = -6
+	},
 /turf/floor/tiled,
 /area/ship/trade/crew/saloon)
 "JX" = (
@@ -6902,6 +6919,12 @@
 /obj/machinery/door/firedoor,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/port)
+"Ke" = (
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/floor/plating/airless,
+/area/space)
 "Kh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7410,14 +7433,15 @@
 "PF" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/box/fancy/egg_box,
-/obj/item/box/fancy/egg_box,
 /obj/item/chems/condiment/flour,
 /obj/item/chems/condiment/flour,
 /obj/item/chems/condiment/flour,
-/obj/random/drinkbottle,
-/obj/random/drinkbottle,
-/obj/random/drinkbottle,
+/obj/item/chems/condiment/yeast,
+/obj/item/chems/condiment/sugar,
+/obj/item/food/butchery/meat/fish,
+/obj/item/food/butchery/meat/fish,
+/obj/item/food/butchery/meat/fish,
+/obj/item/food/butchery/meat/fish,
 /turf/floor/tiled,
 /area/ship/trade/crew/kitchen)
 "PH" = (
@@ -7746,6 +7770,13 @@
 /obj/effect/decal/cleanable/filth,
 /turf/floor/tiled/techmaint,
 /area/ship/trade/crew/hallway/starboard)
+"SP" = (
+/obj/structure/sign/warning/vacuum{
+	dir = 4;
+	pixel_x = -34
+	},
+/turf/floor/tiled/monotile,
+/area/ship/trade/dock)
 "SQ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -7856,12 +7887,18 @@
 /area/ship/trade/command/hallway)
 "UD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice,
 /obj/structure/handrail{
 	dir = 4
 	},
-/turf/space,
+/turf/floor/plating/airless,
 /area/ship/trade/maintenance/engine/port)
+"UE" = (
+/obj/structure/sign/warning/vacuum{
+	dir = 8;
+	pixel_x = 34
+	},
+/turf/floor/tiled/monotile,
+/area/ship/trade/dock)
 "UP" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "scram"
@@ -10538,8 +10575,8 @@ NF
 UD
 JN
 gm
-cy
-Lx
+bB
+Ke
 aa
 aa
 aa
@@ -11171,7 +11208,7 @@ xS
 xS
 Jk
 BZ
-Mw
+SP
 tg
 Ce
 EM
@@ -11253,7 +11290,7 @@ aQ
 Vd
 Ob
 oK
-bB
+UV
 tg
 bN
 bQ
@@ -11991,7 +12028,7 @@ aV
 Rq
 ER
 Pp
-Mw
+UE
 UV
 lj
 at

--- a/maps/tradeship_alt/tradeship-3.dmm
+++ b/maps/tradeship_alt/tradeship-3.dmm
@@ -951,6 +951,12 @@
 	},
 /turf/floor/tiled/dark,
 /area/ship/trade/drunk_tank)
+"qI" = (
+/obj/structure/sign/warning/armory{
+	pixel_x = 32
+	},
+/turf/floor/tiled/monotile,
+/area/ship/trade/command/bridge_upper)
 "qP" = (
 /obj/structure/bed/chair{
 	icon = 'icons/obj/watercloset.dmi';
@@ -1512,6 +1518,13 @@
 	icon_state = "bulb1"
 	},
 /obj/effect/floor_decal/corner/red/mono,
+/obj/item/clothing/costume/yinglet/speardance,
+/obj/item/clothing/gloves/armguards/yinglet/riot,
+/obj/item/clothing/shoes/legguards/yinglet/riot,
+/obj/item/clothing/suit/jacket/winter/yinglet/HoS,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/hos/jensen,
+/obj/item/clothing/head/cowboy_hat,
 /turf/floor/tiled/dark/monotile,
 /area/ship/trade/bridge_security)
 "KK" = (
@@ -5342,7 +5355,7 @@ Xb
 ja
 vR
 Ty
-PZ
+qI
 ZT
 SQ
 ax


### PR DESCRIPTION
## Description of changes
Various jobs on Fishfinder updated, as well as some minor map additions

## Why and what will this PR improve
Will improve what makes sense for jobs, and the items that come in their loadout.

## Authorship
Cegmeister

## Changelog
:cl:
add: Added coffee dispenser, soft drink dispenser, dairy fridge, and yeast to bar
add: Added fabricators to science, mech wreckage to cargo bay
add: Added yinglet security equipment to bridge security
tweak: tweaked loadout items for yinglet patriarchs, gave default role headsets
balance: yinglet scouts are no longer capped at basic literacy
/:cl:
