### PR TITLE
Wordening fixes

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/summit/summit.dm
+++ b/maps/random_ruins/exoplanet_ruins/summit/summit.dm
@@ -307,7 +307,7 @@ var/global/ruinstate = 0
 
 /obj/machinery/power/supermatter/nullmatter
 	name = "nullmatter condensate"
-	desc = "Nothing. Absolute physical nothing that seems impossible to exist. Your head hurts."
+	desc = "Nothing. Absolute physical nothing that ought to be impossible to exist. Your head hurts."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "singularity_s1"
 	explosion_point = 150;
@@ -355,7 +355,7 @@ var/global/ruinstate = 0
 			global.notifiednullmatter = 1
 	else
 		if(!global.notifiednullmatter)
-			to_world("You feel like something has been made RIGHT. Reeality is healing")
+			to_world("Suddenly, you feel a wave of wrongness wash over you - then fade just as quickly, replaced with a sense of euphoric calm. The frayed edges of reality are healing.")
 			global.notifiednullmatter = 1
 		global.notifiedend = 1
 		explosion(src, 3, 4, 5, 6, 1)

--- a/mods/valsalia/species/languageOldYing.dm
+++ b/mods/valsalia/species/languageOldYing.dm
@@ -159,14 +159,14 @@
 		"-orurari" = list("million"),
 		"-orurarisu" = list("billion"),
 		"-oruraratu" = list("trillion"),
-		"-oru-oru-ra" = list("immeasurable", "forever", "eternal", "eternity", "infinite", "inifinity", "ouroboros", "loop", "looping")
+		"-oru-oru-ra" = list("immeasurable", "forever", "eternal", "eternity", "infinite", "inifinity", "ouroboros", "loop", "looping"),
 		"zhat" = list("zhat"),
  		"zhose" = list("zhose"),
  		"zhem" = list("zhem"),
  		"zhey" = list("zhey"),
  		"zhe" = list("zhe"),
  		"zhey're" = list("zhey're"),
- 		"zheir" = list("zheir"),
+ 		"zheir" = list("zheir")
 	)
 
 	var/list/outext = list()

--- a/mods/valsalia/species/languageOldYing.dm
+++ b/mods/valsalia/species/languageOldYing.dm
@@ -1,6 +1,6 @@
 /decl/language/varak
-	name = "Old Yingish"
-	desc = "An offshoot of Olde Common, rendered unrecognizable after centuries of use by far-off Yinglet enclaves."
+	name = "Olde Yinglish"
+	desc = "An offshoot of Old Common, rendered unrecognizable after centuries of use by far-off Yinglet enclaves."
 	speech_verb = "states"
 	exclaim_verb = "objects"
 	ask_verb = "inquiries"
@@ -160,6 +160,13 @@
 		"-orurarisu" = list("billion"),
 		"-oruraratu" = list("trillion"),
 		"-oru-oru-ra" = list("immeasurable", "forever", "eternal", "eternity", "infinite", "inifinity", "ouroboros", "loop", "looping")
+		"zhat" = list("zhat"),
+ 		"zhose" = list("zhose"),
+ 		"zhem" = list("zhem"),
+ 		"zhey" = list("zhey"),
+ 		"zhe" = list("zhe"),
+ 		"zhey're" = list("zhey're"),
+ 		"zheir" = list("zheir"),
 	)
 
 	var/list/outext = list()


### PR DESCRIPTION
Summit explosion description tweaks.
Important 'zhe' words added to Old Yinglish (remember, 'zhe' is a new ying-ism compared to 'the'! Probably. idk.)