### PR TITLE
Slight Murphy changes

### DIFF
--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -7419,6 +7419,10 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
+/obj/item/clothing/gloves/ring/material/silver{
+	desc = "A symbol of a promise.  Engraved on the inside of the band is the text \"Keep her safe.  Keep her happy.\"";
+	name = "Jackson's Ring"
+	},
 /turf/floor/wood,
 /area/ministation/Murphy/bedroom/Vayryn)
 "vE" = (
@@ -7743,8 +7747,7 @@
 /obj/item/clothing/webbing/holster/hip,
 /obj/item/clothing/webbing/holster/waist,
 /obj/item/clothing/webbing/holster/armpit,
-/obj/item/secure_storage/safe,
-/obj/item/gun/projectile/flare/loaded,
+/obj/structure/closet/secure_closet/guncabinet,
 /turf/floor/reinforced,
 /area/ministation/Murphy/common/upper)
 "wz" = (
@@ -7842,8 +7845,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/item/rig/eva,
-/obj/item/powersink,
+/obj/item/rig/ce/equipped,
+/obj/item/rig_module/power_sink,
 /turf/floor,
 /area/ministation/Murphy/maint/Vayryn)
 "wO" = (
@@ -10597,7 +10600,6 @@
 /obj/item/clothing/head/beret/orange,
 /obj/item/clothing/head/beret/corp/sec/corporate/hos,
 /obj/item/clothing/shoes/jackboots/jungleboots,
-/obj/item/clothing/gloves/ring/material/silver,
 /obj/item/clothing/webbing/pouches/large/tan,
 /obj/machinery/light/small{
 	dir = 4


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/ScavStation/ScavStation/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Re-adds a few things that were mistakenly removed:
* Vayryn's Bedroom Maints - Change hardsuit back to Chief Engineer hardsuit, change power sink back to hardsuit module version of power sink
* Jackson's Room - Change secure wall safe to locking gun cabinet, remove flare gun
* Both - Move silver ring from Jackson's wardrobe to Vayryn's room (and add custom name/description)
* Other - Remove two hardsuit module power sinks accidentally placed in space

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Items were removed for balance reasons, and some additional items were removed by accident, but the wrong versions were restored.  This restores the items to the intended, lore-accurate items.  Also moves the silver ring to reflect story events.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
add: `/obj/item/rig/ce/equipped` and `/obj/item/rig_module/power_sink` to Vayryn's Bedroom Maint
add: `/obj/structure/closet/secure_closet/guncabinet` in Jackson's Room (secret area)
del: `/obj/item/rig/eva` and `/obj/item/powersink` from Vayryn's Bedroom Maint
del: `/obj/item/secure_storage/safe` and `/obj/item/gun/projectile/flare/loaded` from Jackson's Room (secret area)
del: Two `/obj/item/rig_module/power_sink` instances, one in space, one embedded inside hull.
tweak: `/obj/item/clothing/gloves/ring/material/silver` moved from Jackson's Room (wardrobe) to Vayryn's Bedroom (computer), given `name = "Jackson's Ring"` and `desc = "A symbol of a promise.  Engraved on the inside of the band is the text \"Keep her safe.  Keep her happy.\""`
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->