### PR TITLE
More Events / Event Adjustments / Dr. Gibb Elixir of Gods

### DIFF
--- a/maps/valSal_port/valSal_port_events.dm
+++ b/maps/valSal_port/valSal_port_events.dm
@@ -20,7 +20,8 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Bristleback Attack", /datum/event/bristleback_attack, 25, list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Bandit Attack", /datum/event/thug_attack, 25, list(ASSIGNMENT_SECURITY = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm", /datum/event/solar_storm_valsal, 25),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Frost Storm", /datum/event/frost_storm, 25)
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Frost Storm", /datum/event/frost_storm, 25),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Strike", /datum/event/meteor_strike, 25)
 	)
 
 /datum/event_container/major/fantasy

--- a/mods/valsalia/_valsalia.dme
+++ b/mods/valsalia/_valsalia.dme
@@ -9,6 +9,7 @@
 #include "events\bandit_attack.dm"
 #include "events\frost_storm.dm"
 #include "events\infestation_valsal.dm"
+#include "events\meteor_strike.dm"
 #include "events\random_bear_walks_in.dm"
 #include "events\solar_storm_valsal.dm"
 #include "items\books.dm"

--- a/mods/valsalia/_valsalia.dme
+++ b/mods/valsalia/_valsalia.dme
@@ -39,6 +39,7 @@
 #include "items\javelin.dm"
 #include "items\mollusc.dm"
 #include "items\prosthetics.dm"
+#include "items\medicines\pancea.dm"
 #include "items\sec_vend.dm"
 #include "items\med_vend.dm"
 #include "items\seed_storage.dm"

--- a/mods/valsalia/events/bandit_attack.dm
+++ b/mods/valsalia/events/bandit_attack.dm
@@ -1,5 +1,3 @@
-var/global/list/bandit_count = list() // Track spawned bandits by Z level
-
 /datum/event/thug_attack
 	announceWhen = 45
 	endWhen = 75
@@ -9,55 +7,54 @@ var/global/list/bandit_count = list() // Track spawned bandits by Z level
 	announceWhen = rand(30, 60)
 	endWhen += severity * 25
 
-/datum/event/thug_attack/tick()
+/datum/event/thug_attack/start()
 	spawn_bandits()
 
-/datum/event/thug_attack/start()
-	// Initialize tracking for this event's Z levels
-	for(var/Z in affecting_z)
-		if(!bandit_count[num2text(Z)])
-			bandit_count[num2text(Z)] = list()
-
 /datum/event/thug_attack/announce()
-	var/stealth_chance = 70 - 20*severity
-	if(prob(stealth_chance))
-		return
 	var/naming
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)
 			naming = "stragglers"
 		if(EVENT_LEVEL_MODERATE)
-			naming = "group"
+			naming = "roamers"
 		if(EVENT_LEVEL_MAJOR)
-			naming = "division"
-	priority_stealth.Announce_quiet("A bandit [naming] has been detected.")
+			naming = "attackers"
+	priority_stealth.Announce_quiet("Bandit [naming] are moving in on the enclave for supplies.")
+
+/datum/event/thug_attack/proc/get_spawn_turfs()
+	var/area/location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area, /proc/is_outside_area))
+	if(!location)
+		log_debug("Bandit attack failed to find a viable area. Aborting.")
+		kill()
+		return
+
+	var/list/turfs = get_area_turfs(location, list(/proc/not_turf_contains_dense_objects, /proc/IsTurfAtmosSafe))
+	if(!turfs.len)
+		log_debug("Bandit attack failed to find viable turfs in \the [location.proper_name].")
+		kill()
+		return
+	return turfs
 
 /datum/event/thug_attack/proc/spawn_bandits()
-	var/direction = pick(global.cardinal)
-	var/Z = pick(affecting_z)
+	var/n = 0
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			n = 4
+		if(EVENT_LEVEL_MODERATE)
+			n = 7
+		if(EVENT_LEVEL_MAJOR)
+			n = 10
 
-	var/n = rand(severity * 0.5, severity * 0.75)
-	var/i = 0
-	while(i < n)
-		var/turf/T = get_random_edge_turf(direction, TRANSITIONEDGE + 2, Z)
-		if(T && !T.density)
-			var/mob/living/simple_animal/hostile/thug/M = new(T)
-			events_repository.register(/decl/observ/death, M, src, TYPE_PROC_REF(/datum/event/thug_attack, reduce_bandit_count))
-			events_repository.register(/decl/observ/destroyed, M, src, TYPE_PROC_REF(/datum/event/thug_attack, reduce_bandit_count))
-			LAZYADD(bandit_count[num2text(Z)], M)
-			spawned_thugs++
-		i++
-		if(i > 5)  // Limit per tick to prevent spawn lag
+	var/list/spots = get_spawn_turfs()
+	if(!LAZYLEN(spots))
+		return
+
+	for(var/i = 1 to n)
+		if(!LAZYLEN(spots))
 			break
+		var/turf/T = pick_n_take(spots)
+		new /mob/living/simple_animal/hostile/thug_aggresive(T)
+		spawned_thugs++
 
 /datum/event/thug_attack/end()
 	log_debug("Bandit attack event spawned [spawned_thugs] bandits.")
-
-/datum/event/thug_attack/proc/reduce_bandit_count(var/mob/M)
-	for(var/Z in affecting_z)
-		var/list/L = bandit_count[num2text(Z)]
-		if(M in L)
-			LAZYREMOVE(L, M)
-			break
-	events_repository.unregister(/decl/observ/death, M, src, TYPE_PROC_REF(/datum/event/thug_attack, reduce_bandit_count))
-	events_repository.unregister(/decl/observ/destroyed, M, src, TYPE_PROC_REF(/datum/event/thug_attack, reduce_bandit_count))

--- a/mods/valsalia/events/bristleback_attack.dm
+++ b/mods/valsalia/events/bristleback_attack.dm
@@ -14,9 +14,6 @@
 			new/mob/living/simple_animal/hostile/bristleback(T)
 
 /datum/event/bristleback_attack/announce()
-	var/stealth_chance = 70 - 20*severity
-	if(prob(stealth_chance))
-		return
 	var/naming
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)
@@ -27,8 +24,11 @@
 			naming = "big pack pack"
 	priority_stealth.Announce_quiet("A bristleback [naming] has been detected.")
 
+/proc/is_outside_area(var/area/A)
+	. = istype(A) && (A.is_outside == OUTSIDE_YES)
+
 /datum/event/bristleback_attack/proc/get_infestation_turfs()
-	var/area/location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area, /proc/is_maint_area))
+	var/area/location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area, /proc/is_outside_area))
 	if(!location)
 		log_debug("Bristleback attack failed to find a viable area. Aborting.")
 		kill()

--- a/mods/valsalia/events/meteor_strike.dm
+++ b/mods/valsalia/events/meteor_strike.dm
@@ -1,0 +1,23 @@
+/datum/event/meteor_strike
+	announceWhen = 5
+	startWhen = 10
+	endWhen = 15
+
+/datum/event/meteor_strike/announce()
+	priority_stealth.Announce_quiet("A shooting star is shooting towards the enclave, find cover!")
+
+/datum/event/meteor_strike/start()
+	var/turf/T = pick_area_and_turf(
+		list(/proc/is_not_space_area, /proc/is_station_area, /proc/is_outside_area),
+		list(/proc/not_turf_contains_dense_objects)
+	)
+
+	if(!T)
+		log_debug("Meteor strike failed to find a viable outdoor turf. Aborting.")
+		kill()
+		return
+
+	var/area/impact_area = get_area(T)
+	var/radius = rand(1, 4)
+	log_and_message_admins("Meteor strike detonating at [T] (radius [radius]) in \the [impact_area.proper_name]", location = T)
+	explosion(T, max(0, radius - 3), max(0, radius - 2), radius, radius + 1, 0)

--- a/mods/valsalia/items/medicines/pancea.dm
+++ b/mods/valsalia/items/medicines/pancea.dm
@@ -1,0 +1,15 @@
+/obj/item/chems/drinks/cans/panacea
+	name = "\improper Panacea"
+	desc = "A shimmering liquid that smells faintly of miracles. One sip is all it takes."
+	icon_state = "cola"
+	center_of_mass = @'{"x":16,"y":10}'
+
+/obj/item/chems/drinks/cans/panacea/attack_self(mob/user)
+	if(!ATOM_IS_OPEN_CONTAINER(src))
+		return open(user)
+	var/mob/living/L = user
+	if(!istype(L))
+		return
+	to_chat(L, SPAN_NOTICE("You drink \the [src] in one gulp. A warm feeling washes over you — you feel completely restored!"))
+	L.revive()
+	qdel(src)

--- a/mods/valsalia/mobs/thugs.dm
+++ b/mods/valsalia/mobs/thugs.dm
@@ -14,6 +14,24 @@
 	var/corpse = /obj/abstract/landmark/corpse/thug
 	var/weapon = /obj/item/bladed/shortsword
 
+
+/mob/living/simple_animal/hostile/thug_aggresive
+	name = "Thug"
+	desc = "A man looking thug. Don't get near..."
+	faction = "thug"
+	icon = 'mods/valsalia/icons/mobs/simple_animal/bandit.dmi'
+	move_intents = list(
+		/decl/move_intent/walk/animal,
+		/decl/move_intent/run/animal
+	)
+	max_health = 75
+	natural_weapon = /obj/item/natural_weapon/punch
+	ai = /datum/mob_controller/aggressive/thug_kill_on_sight
+	base_movement_delay = 1
+	var/corpse = /obj/abstract/landmark/corpse/thug
+	var/weapon = /obj/item/bladed/shortsword
+
+
 /mob/living/simple_animal/hostile/thug/bandit/Initialize()
 	. = ..()
 
@@ -23,6 +41,13 @@
 	emote_see    = list("looks around","sneezes", "stretches")
 	emote_hear   = list("walks around")
 	only_attack_enemies = TRUE
+
+/datum/mob_controller/aggressive/thug_kill_on_sight
+	speak_chance = 1.25
+	emote_speech = list("Hmm?","I hate this place!","Fuck off")
+	emote_see    = list("looks around","sneezes", "stretches")
+	emote_hear   = list("walks around")
+	only_attack_enemies = FALSE
 
 /mob/living/simple_animal/hostile/thug/death(gibbed)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Adds meteor strike event for ground based map. Adjusted bandit attack to just spawn a single wave instead of a constant wave for a time period. Made spawns for bristlebacks and bandits only be outside, added a is_outside proc check for turfs. Added a panacea item that calls human revive to give an item for lessening admin requests for heals

## Why and what will this PR improve
More events, events to be less annoying, ability to not die on maps with obscure medical systems

## Authorship
SpentAppleRods

## Changelog
:cl:
add: Added new things
tweak: tweaked a few things
balance: rebalanced something
:cl: